### PR TITLE
refactor: consolidate kill helpers, validate engine inputs

### DIFF
--- a/appServer/backend/engine.js
+++ b/appServer/backend/engine.js
@@ -88,40 +88,19 @@ function killSpecificEngine(identifierObj, code) {
     }
 }
 
-function findAliveEngineObjectsById(engineId) {
-    return aliveEngineProcesses.filter(ep => ep.identifierObj.engineId === engineId);
+const KILLABLE_FIELDS = new Set(['engineId', 'instanceId', 'profileName']);
+
+function findAliveBy(field, value) {
+    return aliveEngineProcesses.filter(ep => ep.identifierObj[field] === value);
 }
 
-function findAliveEngineObjectsByInstanceId(instanceId) {
-    return aliveEngineProcesses.filter(ep => ep.identifierObj.instanceId === instanceId);
-}
+export function killAllBy(field, value, reason) {
+    if(!KILLABLE_FIELDS.has(field)) {
+        console.warn(`[engine] killAllBy: unknown field "${field}"`);
+        return;
+    }
 
-function findAliveEngineObjectsByProfileName(profileName) {
-    return aliveEngineProcesses.filter(ep => ep.identifierObj.profileName === profileName);
-}
-
-export function killAllEngineIds(engineId, reason) {
-    const allEngineObjs = findAliveEngineObjectsById(engineId);
-
-    allEngineObjs.forEach(o => {
-        killSpecificEngine(o.identifierObj, reason);
-    });
-}
-
-export function killAllEngineInstanceIds(instanceId, reason) {
-    const allEngineObjs = findAliveEngineObjectsByInstanceId(instanceId);
-
-    allEngineObjs.forEach(o => {
-        killSpecificEngine(o.identifierObj, reason);
-    });
-}
-
-export function killAllEngineProfileNames(profileName, reason) {
-    const allEngineObjs = findAliveEngineObjectsByProfileName(profileName);
-
-    allEngineObjs.forEach(o => {
-        killSpecificEngine(o.identifierObj, reason);
-    });
+    findAliveBy(field, value).forEach(o => killSpecificEngine(o.identifierObj, reason));
 }
 
 export function killAllEngines() {
@@ -300,6 +279,7 @@ async function startEngineProcess(enginePath, identifierObj) {
 
 export async function addEngine(fileInfo, title = fileInfo?.name) {
     if(!fileInfo?.path) return 'Missing file path';
+    if(!fs.existsSync(fileInfo.path)) return `Engine file not found: ${fileInfo.path}`;
 
     const isDuplicate = savedEngines.some(engine => engine.path === fileInfo.path);
     if(isDuplicate) return `Engine already exists: ${fileInfo.name}`;
@@ -321,14 +301,19 @@ export async function addEngine(fileInfo, title = fileInfo?.name) {
 }
 
 export function removeEngine(index) {
+    if(!Number.isInteger(index) || index < 0 || index >= savedEngines.length)
+        return `Invalid engine index: ${index}`;
+
+    const savedEngineObj = savedEngines[index];
+
     try {
-        const savedEngineObj = savedEngines[index];
         savedEngines.splice(index, 1);
         store.set(chessEnginesStorageKey, savedEngines);
 
-        killAllEngineIds(savedEngineObj.engineId, 'Engine was removed');
+        killAllBy('engineId', savedEngineObj.engineId, 'Engine was removed');
         renderEngineGrid();
     } catch(e) {
+        console.error('[engine] removeEngine failed:', e);
         return 'Something went wrong while removing the engine, please restart the software.';
     }
 

--- a/appServer/backend/server.js
+++ b/appServer/backend/server.js
@@ -3,8 +3,8 @@ import { mainWindow } from './main.js';
 import { WebSocketServer } from 'ws';
 import http from 'http';
 
-import { findAliveEngineObj, updateAliveEngineObjFen, killAllEngineIds, killAllEngineInstanceIds,
-    killAllEngineProfileNames, saveEngineOptions, sendToProcess, startEngine, savedEngines } from './engine.js';
+import { findAliveEngineObj, updateAliveEngineObjFen, killAllBy,
+    saveEngineOptions, sendToProcess, startEngine, savedEngines } from './engine.js';
 
 const PORT = 2800;
 const ALLOWED_ORIGIN = [
@@ -32,11 +32,12 @@ async function handleClientUciCommand(cmdObj) {
     if(command.length > 512)
         throw new Error('Command too long');
 
-    // savedEngineObj = e.g. { "title": "custom", "name": "lc0.exe", "path": "C:\\Users\\Acas\\Downloads\\lc0\\lc0.exe", "engineId": 1659824228 }
+    // savedEngineObj = e.g. { "title": "custom", "name": "lc0.exe", "path": "...", "engineId": "<sha256 hex>" }
     // Different from aliveEngineObj!
     const savedEngineObj = savedEngines.find(e => e.engineId === engineId);
 
     if(!savedEngineObj) {
+        console.warn(`[server] Unknown engineId received from client: "${engineId}"`);
         toast('warning', `Web command ignored, such engine does not exist!\n(EngineID: "${engineId}")`, 1000);
         return;
     }
@@ -90,23 +91,11 @@ function onCommandReceived(remoteCommand) {
                 sendEnginesList();
                 break;
 
-            case 'closeEnginesByIdentifier':
-                const identifier = msg.identifier;
-                const identifierType = msg.type;
-
-                switch(identifierType) {
-                    case 'engineId':
-                        killAllEngineIds(identifier, `All engines with engineId "${identifier}" were closed by client`);
-                        break;
-                    case 'profileName':
-                        killAllEngineProfileNames(identifier, `All engines with profileName "${identifier}" were closed by client`);
-                        break;
-                    case 'instanceId':
-                        killAllEngineInstanceIds(identifier, `All engines with instanceId "${identifier}" were closed by client`);
-                        break;
-                }
-                
+            case 'closeEnginesByIdentifier': {
+                const { identifier, type: field } = msg;
+                killAllBy(field, identifier, `All engines with ${field} "${identifier}" were closed by client`);
                 break;
+            }
 
             default:
                 throw new Error(`Unknown type: ${type}`);


### PR DESCRIPTION
- Replace 6 near-duplicate find/kill helpers with a single killAllBy(field, value, reason), guarded by a whitelist of allowed fields (engineId / instanceId / profileName).
- removeEngine: validate index before splicing; previously an out-of-range index would splice first, then throw on undefined.engineId, leaving state inconsistent.
- addEngine: bail out early if the engine file no longer exists, instead of throwing from readFile inside createEngineID.
- Fix outdated comment claiming engineId is a number; it's been a sha256 hex string since createEngineID switched to hashing.
- Log unknown engineId from client to console (toast alone disappears in 1s).