### PR TITLE
Fix small bugs in engine reload and init

### DIFF
--- a/app/assets/js/MoveEvaluator.js
+++ b/app/assets/js/MoveEvaluator.js
@@ -70,7 +70,7 @@ export default class MoveEvaluator {
 
             console.warn('[MoveEvaluator] Hold on, rebooting! Attempt:', this.rebootAttempts);
 
-            setTimeout(this.loadStockfish(this.engineName), 100);
+            setTimeout(() => this.loadStockfish(this.engineName), 100);
         }
     }
 

--- a/app/assets/js/init.js
+++ b/app/assets/js/init.js
@@ -78,6 +78,9 @@ async function initializeDatabase() {
     const expiredKeys = await Promise.all(
         tempValueKeys.map(async key => {
             const configValue = await USERSCRIPT.getValue(key);
+            // Treat malformed/missing entries as expired so they get cleaned up,
+            // and avoid crashing initializeDatabase() on a TypeError.
+            if(!configValue || typeof configValue.date !== 'number') return key;
             const isExpired = Date.now() - configValue.date > 6e4 * 60;
             return isExpired ? key : null;
         })

--- a/app/assets/js/instance/loadEngine.js
+++ b/app/assets/js/instance/loadEngine.js
@@ -224,7 +224,7 @@ export default async function loadEngine(profileName, engineName, attempt = 0) {
         const lozza = new Worker(`../app/assets/engines/Lozza/lozza-${version}.js`);
 
         lozza.onmessage = e => processEngineMessage(e.data);
-        lozza.onerror = e => restartEngine('lozza-' + version, e);
+        lozza.onerror = e => restartEngine.bind(this)('lozza-' + version, e);
 
         this.engines.push({
             'type': profileChessEngine,


### PR DESCRIPTION
Three unrelated small fixes.
MoveEvaluator reboot: setTimeout(this.loadStockfish(this.engineName), 100) calls loadStockfish immediately and passes undefined to setTimeout, so the 100ms delay never applies. Wrapped in an arrow.
Lozza onerror: missing bind(this), so when the worker actually crashes restartEngine throws at this.close(). Other engines already bind, this matches them.
initializeDatabase: if a temp value is null or has no .date the Promise.all map throws and aborts GUI init. Treat those as expired so they get cleaned up.