### PR TITLE
Fix interface polling crash after instance close

### DIFF
--- a/app/assets/js/AcasInstance.js
+++ b/app/assets/js/AcasInstance.js
@@ -836,9 +836,10 @@ export default class AcasInstance {
                 clearInterval(g);
 
                 this.interfacePollingActive = false;
+                return;
             }
 
-            const additionalInfoElem = this.instanceElem.querySelector('.instance-additional-info');
+            const additionalInfoElem = this.instanceElem?.querySelector('.instance-additional-info');
             const lastActiveEnginesAmount = this.activeEnginesAmount;
             const lastVariantNotSupportedByEngineAmount = this.variantNotSupportedByEngineAmount;
 
@@ -877,7 +878,7 @@ export default class AcasInstance {
             }
 
             if(newInfoStr.length > 0) {
-                additionalInfoElem.innerText = newInfoStr;
+                if(additionalInfoElem) additionalInfoElem.innerText = newInfoStr;
 
                 updatePipData({ 'engineText': newInfoStr });
             }


### PR DESCRIPTION
## Summary
- `AcasInstance.startInterfacePolling` cleared its interval when `instanceClosed` became true but did not `return`, so the same tick kept reading `this.instanceElem` and `this.pV` after `close()` had run.
- Added an early `return` and guarded `additionalInfoElem` with optional chaining so the final tick on a removed instance element no longer throws.