### PR TITLE
Guard nullable querySelector results and drop debug logs

### DIFF
--- a/app/assets/js/gui/profiles.js
+++ b/app/assets/js/gui/profiles.js
@@ -51,14 +51,14 @@ async function deleteProfile(profileName) {
 
 function selectNearestProfileTab(tabsElem, profileName) {
     const listContainerElem = tabsElem.querySelector('.tabs-list-container');
+    if(!listContainerElem) return;
+
     const listTabItems = [...listContainerElem.children].filter(x => x?.dataset?.value);
     const formattedName = GET_PROFILE_STORAGE_KEY(profileName);
     const indexOfCurrentTab = listTabItems.findIndex(x => x.dataset.value === formattedName);
 
     if(indexOfCurrentTab && indexOfCurrentTab >= 1) {
         const nearestTabToLeft = listTabItems[indexOfCurrentTab - 1];
-
-        console.log(nearestTabToLeft);
 
         setTimeout(() => {
             nearestTabToLeft?.click();
@@ -165,11 +165,14 @@ function removeProfileTabItem(tabsElem, itemValue, newValue) {
     const dropdownItem = tabsElem.querySelector(`*[data-value="${encodedName}"]`);
     const dropdownInput = tabsElem.querySelector('input[data-default-value]');
 
+    if(!dropdownInput) {
+        dropdownItem?.remove();
+        return;
+    }
+
     dropdownInput.value = (newValue || dropdownInput.dataset.defaultValue);
 
     dropdownItem?.remove();
-
-    console.log(dropdownInput, dropdownInput.value);
 
     dropdownInput.dispatchEvent(new Event('change'));
 }

--- a/app/assets/js/gui/stats.js
+++ b/app/assets/js/gui/stats.js
@@ -1,7 +1,9 @@
 import { beggingFloaty, userStatElements } from './elementDeclarations.js';
 
 function showBeggingFloaty(minutes) {
-    const hoursText = beggingFloaty.querySelector('b');
+    const hoursText = beggingFloaty?.querySelector('b');
+    if(!hoursText) return;
+
     hoursText.innerText = Math.round(minutes / 60);
 
     beggingFloaty.showModal();


### PR DESCRIPTION
## Summary
- `selectNearestProfileTab` and `removeProfileTabItem` in `profiles.js` blindly dereferenced `tabsElem.querySelector(...)` results. Added early-return guards so a missing `.tabs-list-container` or default-value input no longer throws.
- `showBeggingFloaty` in `stats.js` did the same on `beggingFloaty.querySelector('b')`; added a null guard.
- Removed two leftover `console.log` debug calls in `profiles.js`.