### PR TITLE
Guard postMessage event.data and simplify FEN piece count

### DIFF
--- a/app/assets/js/globals.js
+++ b/app/assets/js/globals.js
@@ -475,10 +475,10 @@ function COUNT_TOTAL_PIECES_FROM_FEN(fen) {
 
     for(let char of position) {
         if(/[rnbqkpRNBQKP]/.test(char)) {
-            pieceCount += (pieceCount[char] || 0) + 1;
+            pieceCount++;
         }
     }
-    
+
     return pieceCount;
 }
 

--- a/app/assets/js/misc/userscriptBridge.js
+++ b/app/assets/js/misc/userscriptBridge.js
@@ -5,7 +5,7 @@
             let timeoutId;
 
             const listener = (event) => {
-                if(event.data.messageId === messageId && event.data.sender !== 'GUI') {
+                if(event?.data?.messageId === messageId && event.data.sender !== 'GUI') {
                     clearTimeout(timeoutId);
                     window.removeEventListener('message', listener);
 


### PR DESCRIPTION
## Summary
- `userscriptBridge.js`: the message listener accessed `event.data.messageId` directly, so any unrelated `postMessage` from a browser extension or another frame with no `data` payload would throw inside the listener. Switched to optional chaining.
- `globals.js`: `COUNT_TOTAL_PIECES_FROM_FEN` used `pieceCount += (pieceCount[char] || 0) + 1` on a `Number`. The expression happened to produce the right total (indexing a number returns `undefined`) but reads as if it were per-piece tallying. Replaced with a plain `pieceCount++` so the intent is obvious.