### PR TITLE
fix crash bugs in web app

### DIFF
--- a/app/assets/js/AcasInstance.js
+++ b/app/assets/js/AcasInstance.js
@@ -141,10 +141,12 @@ export default class AcasInstance {
                 const variantFromConfig = await t.getConfigValue(t.configKeys.chessVariant, profileName);
                 const use960FromConfig = await t.getConfigValue(t.configKeys.useChess960, profileName);
 
-                instance.chessVariant = IS_VARIANT_960(chessVariant)
+                const detectedVariant = chessVariant || variantFromConfig;
+
+                instance.chessVariant = IS_VARIANT_960(detectedVariant)
                     ? FORMAT_VARIANT('chess')
-                    : FORMAT_VARIANT(chessVariant || variantFromConfig || 'chess');
-                instance.useChess960 = IS_VARIANT_960(chessVariant) ? true : use960FromConfig;
+                    : FORMAT_VARIANT(detectedVariant || 'chess');
+                instance.useChess960 = IS_VARIANT_960(detectedVariant) ? true : use960FromConfig;
                 instance.lc0WeightName = await t.getConfigValue(t.configKeys.lc0Weight, profileName);
         
                 return instance;

--- a/app/assets/js/BoardAnalyzer.js
+++ b/app/assets/js/BoardAnalyzer.js
@@ -12,7 +12,7 @@ export default class BoardAnalyzer {
         this.isPlayerBlack = (config?.orientation || (fen && fen.split(' ')[1]) || 'w').toLowerCase() === 'b';
         this.board = this.parseFEN();
         this.boardHeight = this.board.length;  // Number of rows in the board
-        this.boardWidth = this.board[0].length;  // Number of columns in the board
+        this.boardWidth = this.board[0]?.length ?? 0;  // Number of columns in the board
 
         this.fenToValue = c => ({ P:1, N:3, B:3, R:5, Q:9, K:100 })[c.toUpperCase()] || 0;
 
@@ -54,6 +54,7 @@ export default class BoardAnalyzer {
     }
 
     parseFEN() {
+        if(!this.fen || typeof this.fen !== 'string') return [];
         if(this.isPlayerBlack) this.flipFen();
 
         const rows = this.fen.split(' ')[0].split('/');

--- a/app/assets/js/MoveEvaluator.js
+++ b/app/assets/js/MoveEvaluator.js
@@ -113,7 +113,7 @@ export default class MoveEvaluator {
         this.searchDepth = configObj?.depth || this.searchDepth;
 
         const [from, to] = moveObj; // e.g. ['a1', 'a2']
-        const playerColor = this.currentFen.split(' ')[1] || 'w';
+        const playerColor = this.currentFen.split(' ')[1];
         const enemyColor = playerColor === 'w' ? 'b' : 'w';
 
         let isMate = 0;

--- a/app/assets/js/MoveEvaluator.js
+++ b/app/assets/js/MoveEvaluator.js
@@ -113,7 +113,7 @@ export default class MoveEvaluator {
         this.searchDepth = configObj?.depth || this.searchDepth;
 
         const [from, to] = moveObj; // e.g. ['a1', 'a2']
-        const playerColor = this.currentFen.split(' ')[1];
+        const playerColor = this.currentFen.split(' ')[1] || 'w';
         const enemyColor = playerColor === 'w' ? 'b' : 'w';
 
         let isMate = 0;

--- a/app/assets/js/gui/settings.js
+++ b/app/assets/js/gui/settings.js
@@ -22,7 +22,7 @@ export function importSettings() {
                 const jsonString = event.target.result;
                 const jsonData = JSON.parse(jsonString);
 
-                if(!'instance' in jsonData) {
+                if(!('instance' in jsonData)) {
                     jsonData['instance'] = {};
                 }
 


### PR DESCRIPTION
Fixes 4 crash/correctness bugs in `app/assets/js/`:

- `AcasInstance.js`: profileVariables.create referenced undefined-looking `chessVariant`. Kept site-detected variant precedence with `detectedVariant = chessVariant || variantFromConfig` so Chess960/variant detection from site still overrides config.
- `gui/settings.js`: `!'instance' in jsonData` was parsed as `(!'instance') in jsonData` (always false). Wrapped with parens.
- `BoardAnalyzer.js`: crashed on null/empty FEN at `this.board[0].length`. Added FEN type guard in `parseFEN` and optional chaining for boardWidth.
- `MoveEvaluator.js`: `currentFen.split(' ')[1]` could be undefined → `cpHistory[undefined].push` crash. Default to `'w'`.