### PR TITLE
fix engine server lifecycle

### DIFF
--- a/appServer/backend/engine.js
+++ b/appServer/backend/engine.js
@@ -270,8 +270,15 @@ async function startEngineProcess(enginePath, identifierObj) {
                     }, 100);
                 });
 
+                let stdoutBuffer = '';
+
                 engineProcess.stdout.on('data', (data) => {
-                    data.toString().split(/\r?\n/).forEach(line => {
+                    stdoutBuffer += data.toString();
+
+                    const lines = stdoutBuffer.split(/\r?\n/);
+                    stdoutBuffer = lines.pop(); // keep the trailing incomplete line for the next chunk
+
+                    lines.forEach(line => {
                         if(line.trim()) sendUciLineToClient(line, engineId, profileName, instanceId);
                         log(line, 'engine', identifierObj);
                     });

--- a/appServer/backend/engine.js
+++ b/appServer/backend/engine.js
@@ -77,9 +77,11 @@ function killSpecificEngine(identifierObj, code) {
     const engineObjToKill = findAliveEngineObj(identifierObj);
 
     if(engineObjToKill) {
-        toast('message', `Killing some engines! (${code || 'Manually/Externally'})`, 4000);
-
         engineObjToKill.engineProcess.kill();
+
+        if(!mainWindow || mainWindow.isDestroyed()) return;
+
+        toast('message', `Killed specific engine! (${code || 'Manually/Externally'})`, 4000);
 
         removeAliveEngineObj(identifierObj);
         refreshEngineCards(aliveEngineProcesses);

--- a/appServer/backend/main.js
+++ b/appServer/backend/main.js
@@ -6,7 +6,7 @@ import os from 'os';
 
 import { killAllEngines, clearCache, addEngine, getSavedEngines, renderEngineGrid,
 	removeEngine, sendManualUciToEngine } from './engine.js';
-import { startLocalWSS, sendEnginesList } from './server.js';
+import { startLocalWSS, stopLocalWSS, sendEnginesList } from './server.js';
 
 export let mainWindow = null;
 
@@ -94,6 +94,11 @@ app.whenReady().then(() => {
 	});
 
     console.log('Ready!');
+});
+
+app.on('before-quit', () => {
+	killAllEngines();
+	stopLocalWSS();
 });
 
 app.on('window-all-closed', () => {

--- a/appServer/backend/server.js
+++ b/appServer/backend/server.js
@@ -1,6 +1,6 @@
 import { toast } from './util.js';
 import { mainWindow } from './main.js';
-import { WebSocketServer } from 'ws';
+import { WebSocketServer, WebSocket } from 'ws';
 import http from 'http';
 
 import { findAliveEngineObj, updateAliveEngineObjFen, killAllBy,
@@ -12,7 +12,22 @@ const ALLOWED_ORIGIN = [
     'https://psyyke.github.io'
 ];
 
-let sendToClient = null;
+const clients = new Set();
+let wssRef = null;
+
+function broadcast(payloadObj) {
+    const data = JSON.stringify(payloadObj);
+
+    for(const ws of clients) {
+        if(ws.readyState === WebSocket.OPEN) {
+            try {
+                ws.send(data);
+            } catch (e) {
+                console.error('Failed to send to a client:', e?.message);
+            }
+        }
+    }
+}
 
 function getIdentifierKey(identifierObj) {
     return identifierObj.engineId + identifierObj.profileName + identifierObj.instanceId;
@@ -131,6 +146,8 @@ export function startLocalWSS() {
     });
 
     wss.on('connection', (ws, request) => {
+        clients.add(ws);
+
         if(wss.onClientChange) wss.onClientChange(true, request.headers.origin);
 
         ws.on('message', (msg) => {
@@ -138,10 +155,10 @@ export function startLocalWSS() {
         });
 
         ws.on('close', () => {
+            clients.delete(ws);
+
             if(wss.onClientChange) wss.onClientChange(false);
         });
-
-        sendToClient = ws.send.bind(ws);
     });
 
     wss.httpServer.on('listening', () => {
@@ -169,23 +186,33 @@ export function startLocalWSS() {
 
     server.listen(PORT, '127.0.0.1');
 
+    wssRef = wss;
+
     return wss;
+}
+
+export function stopLocalWSS() {
+    if(!wssRef) return;
+
+    for(const ws of clients) {
+        try { ws.close(); } catch (e) {}
+    }
+
+    clients.clear();
+
+    wssRef.close();
+    wssRef.httpServer?.close();
+    wssRef = null;
 }
 
 // This doesnt use instanceId, so it will be sent to every A.C.A.S instance
 // might cause issues later on but right now doesn't seem to be a big deal!
 export function sendEnginesList() {
-    if(!sendToClient) return;
-
-    const engines = savedEngines;
-
-    sendToClient(JSON.stringify({ type: 'enginesList', msg: engines }));
+    broadcast({ type: 'enginesList', msg: savedEngines });
 }
 
 // Called from engine.js
 export function sendUciLineToClient(line, engineId, profileName, instanceId) {
-    if(!sendToClient) {
-        console.error('No sendToClient function found while trying to send UCI line!'); return; }
     if(!profileName) {
         console.error('No profileName given to send UCI line function, cannot send!'); return; }
     if(!engineId) {
@@ -194,26 +221,24 @@ export function sendUciLineToClient(line, engineId, profileName, instanceId) {
         console.error('No instanceId given to send UCI line function, cannot send!'); return; }
 
     // Expects e.g. { "type": "uci", "msg": { "line": "info depth 12...", "engineId": 12345, "profileName": "default", "instanceId": "100" } }
-    sendToClient(JSON.stringify({
+    broadcast({
         type: 'uci', msg: { line, engineId, profileName, instanceId }
-    }));
+    });
 }
 
 // Called from engine.js
 // Expected death certificate includes reason, fen, profileName, engineId and instanceId
 export function sendEngineDeathCertificateToClient(reason = 'not given', fen, engineId, profileName, instanceId) {
-    if(!sendToClient) {
-        console.error('No sendToClient function found while trying to send engine death certificate!'); return; }
     if(!profileName) {
         console.error('No profileName given to sendEngineDeathCertificate function, cannot send!'); return; }
     if(!instanceId){
         console.error('No instanceId given to sendEngineDeathCertificate function, cannot send!'); return; }
 
-    sendToClient(JSON.stringify({
+    broadcast({
         'type': 'engineStatusUpdate',
         'msg': {
             'statusType': 'engineDeathCertificate',
             reason, fen, engineId, profileName, instanceId
         }
-    }));
+    });
 }

--- a/appServer/backend/server.js
+++ b/appServer/backend/server.js
@@ -14,9 +14,15 @@ const ALLOWED_ORIGIN = [
 
 const clients = new Set();
 let wssRef = null;
+let warnedAboutMultipleClients = false;
 
-function broadcast(payloadObj) {
+function broadcastToClients(payloadObj) {
     const data = JSON.stringify(payloadObj);
+
+    if(clients.size > 1 && !warnedAboutMultipleClients) {
+        warnedAboutMultipleClients = true;
+        toast('error', `Multiple GUI tabs connected! Please only use one at a time.`, 60000);
+    }
 
     for(const ws of clients) {
         if(ws.readyState === WebSocket.OPEN) {
@@ -162,6 +168,8 @@ export function startLocalWSS() {
     });
 
     wss.httpServer.on('listening', () => {
+        if(!mainWindow || mainWindow.isDestroyed()) return;
+
         const addressObj = wss.httpServer.address();
 
         mainWindow.webContents.send('serverListening', {
@@ -172,6 +180,8 @@ export function startLocalWSS() {
     });
 
     wss.onClientChange = (isConnected, origin) => {
+        if(!mainWindow || mainWindow.isDestroyed()) return;
+
         mainWindow.webContents.send('serverClientChange', {
             isConnected,
             origin
@@ -179,6 +189,8 @@ export function startLocalWSS() {
     };
 
     wss.onUnauthorized = (origin) => {
+        if(!mainWindow || mainWindow.isDestroyed()) return;
+
         mainWindow.webContents.send('serverUnauthorized', {
             origin
         });
@@ -208,7 +220,7 @@ export function stopLocalWSS() {
 // This doesnt use instanceId, so it will be sent to every A.C.A.S instance
 // might cause issues later on but right now doesn't seem to be a big deal!
 export function sendEnginesList() {
-    broadcast({ type: 'enginesList', msg: savedEngines });
+    broadcastToClients({ type: 'enginesList', msg: savedEngines });
 }
 
 // Called from engine.js
@@ -221,7 +233,7 @@ export function sendUciLineToClient(line, engineId, profileName, instanceId) {
         console.error('No instanceId given to send UCI line function, cannot send!'); return; }
 
     // Expects e.g. { "type": "uci", "msg": { "line": "info depth 12...", "engineId": 12345, "profileName": "default", "instanceId": "100" } }
-    broadcast({
+    broadcastToClients({
         type: 'uci', msg: { line, engineId, profileName, instanceId }
     });
 }
@@ -234,7 +246,7 @@ export function sendEngineDeathCertificateToClient(reason = 'not given', fen, en
     if(!instanceId){
         console.error('No instanceId given to sendEngineDeathCertificate function, cannot send!'); return; }
 
-    broadcast({
+    broadcastToClients({
         'type': 'engineStatusUpdate',
         'msg': {
             'statusType': 'engineDeathCertificate',


### PR DESCRIPTION
Fixes a few real issues in the external engine server:

- broadcast engine output to all connected clients instead of a single global `sendToClient` that got overwritten on every new connection (broke multi-instance/multi-tab use)
- kill engines and close the WSS on app quit so engine processes aren't left orphaned
- buffer stdout so UCI lines split across chunks aren't sent broken