### PR TITLE
fix new game reinit crash and engine cleanup bugs

### DIFF
--- a/app/assets/js/AcasInstance.js
+++ b/app/assets/js/AcasInstance.js
@@ -272,7 +272,7 @@ export default class AcasInstance {
 
         if(profileName) {
             setTimeout(() => {
-                this.pV[profileName].pendingCalculations.forEach(x => x.finished = true);
+                this.pV[profileName]?.pendingCalculations?.forEach(x => x.finished = true);
             }, 25);
         }
     }
@@ -301,9 +301,6 @@ export default class AcasInstance {
                 return true;
             case 'updateBoardOrientation':
                 this.Interface.updateBoardOrientation(packet.data);
-                return true;
-            case 'reloadChessEngine':
-                reloadChessEngine();
                 return true;
             case 'updateBoardFen':
                 this.Interface.updateBoardFen(packet.data);

--- a/app/assets/js/instance/engineStartNewGame.js
+++ b/app/assets/js/instance/engineStartNewGame.js
@@ -43,32 +43,39 @@ async function startWithDynamicOptions(variant, engineName, profile) {
     3.) When the chess variant changes. */
 export default async function engineStartNewGame(variant, profile) {
     const chessVariant = FORMAT_VARIANT(variant);
-    const engineName = await this.getEngineName(profile);
-    const playerColor = await this.getPlayerColor(profile);
-    const isAdvancedElo = await this.getConfigValue(this.configKeys.enableAdvancedElo, profile);
 
+    // Global resets run once, before any per-profile work, so looping over
+    // profiles below does not wipe another profile's dynamic-options state.
     resetDynamicOptionsReady();
-
-    if(!profile) {
-        Object.keys(this.pV).forEach(profileName => {
-            this.clearHistoryVariables(profileName);
-        });
-    } else this.clearHistoryVariables(profile);
-
     this.kingMoved = ''; // reset king moved check
 
-    if(this.MoveEval) this.MoveEval.startNewGame(playerColor);
+    const startForProfile = async profileName => {
+        const engineName = await this.getEngineName(profileName);
+        const playerColor = await this.getPlayerColor(profileName);
+        const isAdvancedElo = await this.getConfigValue(this.configKeys.enableAdvancedElo, profileName);
 
-    if(this.isEngineCalculating(profile))
-        this.engineStopCalculating(profile, 'Engine was calculating while a new game was started!');
+        this.clearHistoryVariables(profileName);
 
-    this.sendMsgToEngine('isready', profile); // not really necessary but not bad to have
-    this.sendMsgToEngine('uci', profile); // to display variants and other details
-    this.sendMsgToEngine('ucinewgame', profile); // very important to be before setting variant and so forth
-        
-    if(isAdvancedElo) await startWithDynamicOptions.bind(this)(chessVariant, engineName, profile);
-    else await startWithBasicOptions.bind(this)(chessVariant, engineName, profile);
+        if(this.MoveEval) this.MoveEval.startNewGame(playerColor);
 
-    this.sendMsgToEngine('position startpos', profile);
-    if(engineName !== 'lc0') this.sendMsgToEngine('d', profile);
+        if(this.isEngineCalculating(profileName))
+            this.engineStopCalculating(profileName, 'Engine was calculating while a new game was started!');
+
+        this.sendMsgToEngine('isready', profileName); // not really necessary but not bad to have
+        this.sendMsgToEngine('uci', profileName); // to display variants and other details
+        this.sendMsgToEngine('ucinewgame', profileName); // very important to be before setting variant and so forth
+
+        if(isAdvancedElo) await startWithDynamicOptions.bind(this)(chessVariant, engineName, profileName);
+        else await startWithBasicOptions.bind(this)(chessVariant, engineName, profileName);
+
+        this.sendMsgToEngine('position startpos', profileName);
+        if(engineName !== 'lc0') this.sendMsgToEngine('d', profileName);
+    };
+
+    // When no profile is given (e.g. on a new match) start a new game for every profile.
+    if(!profile) {
+        await Promise.all(Object.keys(this.pV).map(startForProfile));
+    } else {
+        await startForProfile(profile);
+    }
 }

--- a/app/assets/js/instance/engineStartNewGame.js
+++ b/app/assets/js/instance/engineStartNewGame.js
@@ -49,14 +49,15 @@ export default async function engineStartNewGame(variant, profile) {
     resetDynamicOptionsReady();
     this.kingMoved = ''; // reset king moved check
 
+    // MoveEval is shared across the instance, so reset it once with the
+    // instance-level player color (not per-profile) to avoid parallel stomping.
+    if(this.MoveEval) this.MoveEval.startNewGame(await this.getPlayerColor());
+
     const startForProfile = async profileName => {
         const engineName = await this.getEngineName(profileName);
-        const playerColor = await this.getPlayerColor(profileName);
         const isAdvancedElo = await this.getConfigValue(this.configKeys.enableAdvancedElo, profileName);
 
         this.clearHistoryVariables(profileName);
-
-        if(this.MoveEval) this.MoveEval.startNewGame(playerColor);
 
         if(this.isEngineCalculating(profileName))
             this.engineStopCalculating(profileName, 'Engine was calculating while a new game was started!');

--- a/app/assets/js/instance/renderFeedback.js
+++ b/app/assets/js/instance/renderFeedback.js
@@ -82,7 +82,7 @@ export default async function renderFeedback(currentFen) {
 
             let fromFen = lastFen;
             
-            if(shouldReturnPlayerFeedbackDisabled || shouldReturnEnemyFeedbackDisabled) return;
+            if(shouldReturnPlayerFeedbackDisabled || shouldReturnEnemyFeedbackDisabled) continue;
             if(shouldReverseFen) fromFen = REVERSE_FEN_TURN(fromFen);
             if(!this.MoveEval) this.MoveEval = new MoveEvaluator();
 

--- a/app/assets/js/instance/updateSettings.js
+++ b/app/assets/js/instance/updateSettings.js
@@ -14,21 +14,22 @@ export default async function updateSettings(updateObj) {
 
     // Handle profiles which engine is disabled
     for(const profileObj of profilesWithDisabledEngine) {
-        const profileName = profileObj.name;
-        const profileVariables = this.pV[profileName];
+        const disabledProfileName = profileObj.name;
 
-        if(profileVariables) {
-            this.killEngine(profileName);
+        if(this.pV[disabledProfileName]) {
+            this.killEngine(disabledProfileName);
 
-            return;
+            // Only stop here if the changed profile is the one being disabled; killing
+            // an unrelated profile's engine must not abort this profile's update.
+            if(disabledProfileName === profileName) return;
         }
     }
-    
-    // Handle profiles which do not exist anymore
-    for(const profileName of nonexistingProfilesWithEngine) {
-        this.killEngine(profileName);
 
-        return;
+    // Handle profiles which do not exist anymore
+    for(const deadProfileName of nonexistingProfilesWithEngine) {
+        this.killEngine(deadProfileName);
+
+        if(deadProfileName === profileName) return;
     }
 
     const chessVariant = FORMAT_VARIANT(await this.getConfigValue(this.configKeys.chessVariant, profileName));


### PR DESCRIPTION
Fixes several instance-side bugs found while reviewing the web app:

- `reloadChessEngine` packet called an undefined function (`ReferenceError`, silently swallowed). The command was never sent by the userscript, so the dead case is removed.
- `newMatchStarted` ran `engineStartNewGame()` with no profile, hitting `this.pV[undefined]` and throwing before the engine was re-initialised. It now starts a new game for every profile. Global resets (`resetDynamicOptionsReady`, `kingMoved`) stay once so the per-profile loop doesn't wipe shared dynamic-options state.
- `notifyAcasAboutEngineClosing` dereferenced `this.pV[profileName]` in a delayed timeout with no guard; it now uses optional chaining in case the profile was killed in the meantime.
- `renderFeedback` used `return` instead of `continue` inside the profile loop, so one profile with disabled feedback skipped all remaining profiles.
- `updateSettings` returned after killing the first disabled/removed profile's engine, so only one was killed per save and unrelated setting changes were aborted. It now kills all of them and only stops early when the changed profile itself is the one being disabled.