### PR TITLE
fix gui input clamping, dropdown selector, pip dedup and other bugs

### DIFF
--- a/app/assets/js/gui.js
+++ b/app/assets/js/gui.js
@@ -93,7 +93,7 @@ function fillChessVariantDropdowns(arr) {
 function fillTextToSpeechVoices() {
     const waitForTTSVoices = setInterval(() => {
         const ttsVoices = GET_TTS_VOICES();
-        if(ttsVoices?.length === 0) return;
+        if(!ttsVoices?.length) return;
 
         ttsVoices.forEach(x => addDropdownItem(ttsNameDropdownElem, x));
 
@@ -119,7 +119,7 @@ function initializeFloatyButtons() {
             }
         
             btn.onclick = () => (floatyDialog.open ? close() : open());
-            closeBtn.onclick = () => close();
+            if(closeBtn) closeBtn.onclick = () => close();
         
             floatyDialog.onclick = (e) => {
                 const selection = window.getSelection().toString();

--- a/app/assets/js/gui/domDropdown.js
+++ b/app/assets/js/gui/domDropdown.js
@@ -1,5 +1,5 @@
 export function doesDropdownItemExist(dropdownInputElem, itemValue) {
-    return dropdownInputElem.parentElement.querySelector(`*[data-value="${itemValue}"`) ? true : false;
+    return dropdownInputElem.parentElement.querySelector(`*[data-value="${itemValue}"]`) ? true : false;
 }
 
 export function addDropdownItem(dropdownElem, itemValue, itemText) {

--- a/app/assets/js/gui/domInputs.js
+++ b/app/assets/js/gui/domInputs.js
@@ -23,7 +23,11 @@ export function setInputValue(elem, val, min, max) {
                     elem.classList.remove(selectedItemKey);
             });
         } else {
-            if(min && max) val = Math.max(min, Math.min(max, val)) || min;
+            if(min != null && max != null) {
+                const clamped = Math.max(min, Math.min(max, val));
+
+                val = Number.isNaN(clamped) ? min : clamped;
+            }
         }
 
         elem.value = VAR_TO_CORRECT_TYPE(val);
@@ -75,7 +79,9 @@ export function initializeSettingInputElem(elem, skipDefaultValueSet) {
 
     elem.onchange = e => {
         if(isRange && elem.dataset?.between) {
-            e.target.value = Math.max(min, Math.min(max, e.target.value)) || min;
+            const clamped = Math.max(min, Math.min(max, e.target.value));
+
+            e.target.value = Number.isNaN(clamped) ? min : clamped;
         }
 
         if(e.target.value || e.target.checked || e.target.value === '') {

--- a/app/assets/js/gui/dynamicEngineOptions.js
+++ b/app/assets/js/gui/dynamicEngineOptions.js
@@ -31,20 +31,24 @@ export function onDynamicOptionsReady(profileName, timeout = 5000) {
         dynamicOptionsWaiters[profileName] = [];
 
     return new Promise((resolve, reject) => {
-        const timer = setTimeout(() => {
-            dynamicOptionsWaiters[profileName] = dynamicOptionsWaiters[profileName]
-                .filter(w => w.resolve !== resolve);
+        let timer;
 
-            reject(new Error(`Timeout waiting for profile "${profileName}", did not receive UCI options from engine!`));
-        }, timeout);
-
-        dynamicOptionsWaiters[profileName].push({
+        const waiter = {
             resolve: () => {
                 clearTimeout(timer);
                 resolve();
             },
             reject
-        });
+        };
+
+        timer = setTimeout(() => {
+            dynamicOptionsWaiters[profileName] = dynamicOptionsWaiters[profileName]
+                .filter(w => w !== waiter);
+
+            reject(new Error(`Timeout waiting for profile "${profileName}", did not receive UCI options from engine!`));
+        }, timeout);
+
+        dynamicOptionsWaiters[profileName].push(waiter);
     });
 }
 

--- a/app/assets/js/gui/externalEngine.js
+++ b/app/assets/js/gui/externalEngine.js
@@ -73,7 +73,7 @@ export async function updateEnginesList(engines) {
         const alreadyExistingItem = dropdownListContainer.querySelector(`[data-value="${engineId}"]`);
 
         if(alreadyExistingItem) {
-            if(engine.engineId === selectedEngineID) {
+            if(engineId === String(selectedEngineID)) {
                 alreadyExistingItem.click();
                 foundSelectedEngineID = true;
             }
@@ -85,7 +85,7 @@ export async function updateEnginesList(engines) {
         item.className = 'dropdown-item large';
         item.dataset.value = engineId;
 
-        if(engine.engineId === selectedEngineID) {
+        if(engineId === String(selectedEngineID)) {
             item.classList.add(selectedItemClass);
             foundSelectedEngineID = true;
         }
@@ -119,11 +119,9 @@ export async function updateEnginesList(engines) {
         initializeSettingInputElem(paramsInput, true);
     }
 
-    if(!foundSelectedEngineID) {
-        setTimeout(() => {
-            dropdownListContainer?.firstChild?.click();
-        }, 100);
-    } else if(!foundSelectedEngineID && selectedEngineID) {
+    if(foundSelectedEngineID) {
+        // The previously selected engine is present and was already marked/clicked.
+    } else if(selectedEngineID) {
         const notAvailableText = TRANS_OBJ?.noExternalEngineAnymore ?? 'The previously selected EXTERNAL engine is not available anymore. Select a new one.';
 
         toast.warning(`${notAvailableText}${selectedEngineID ? `\n\n(ID: ${selectedEngineID})` : ''}`, 5000);
@@ -133,6 +131,10 @@ export async function updateEnginesList(engines) {
 
         setTimeout(() => {
             input.dispatchEvent(new Event('change'));
+        }, 100);
+    } else {
+        setTimeout(() => {
+            dropdownListContainer?.firstChild?.click();
         }, 100);
     }
 }

--- a/app/assets/js/gui/externalEngine.js
+++ b/app/assets/js/gui/externalEngine.js
@@ -119,20 +119,15 @@ export async function updateEnginesList(engines) {
         initializeSettingInputElem(paramsInput, true);
     }
 
-    if(foundSelectedEngineID) {
-        // The previously selected engine is present and was already marked/clicked.
-    } else if(selectedEngineID) {
-        const notAvailableText = TRANS_OBJ?.noExternalEngineAnymore ?? 'The previously selected EXTERNAL engine is not available anymore. Select a new one.';
+    if(!foundSelectedEngineID) {
+        // If a previously selected engine was stored but is no longer available, warn the user.
+        if(selectedEngineID) {
+            const notAvailableText = TRANS_OBJ?.noExternalEngineAnymore ?? 'The previously selected EXTERNAL engine is not available anymore. Select a new one.';
 
-        toast.warning(`${notAvailableText}${selectedEngineID ? `\n\n(ID: ${selectedEngineID})` : ''}`, 5000);
-        input.value = '';
+            toast.warning(`${notAvailableText}\n\n(ID: ${selectedEngineID})`, 5000);
+        }
 
-        toggleDropdown();
-
-        setTimeout(() => {
-            input.dispatchEvent(new Event('change'));
-        }, 100);
-    } else {
+        // Fall back to the first available engine so one stays active after a refresh.
         setTimeout(() => {
             dropdownListContainer?.firstChild?.click();
         }, 100);

--- a/app/assets/js/gui/instances.js
+++ b/app/assets/js/gui/instances.js
@@ -57,11 +57,13 @@ export function addInstanceToSettingsDropdown(instanceID, domain, chessVariant, 
 
     const highlightedElem = instanceElem.querySelector('.highlight-indicator');
 
-    dropmenuItem.ontouchstart = () => highlightedElem.classList.remove('hidden');
-    dropmenuItem.ontouchend = () => highlightedElem.classList.add('hidden');
+    if(highlightedElem) {
+        dropmenuItem.ontouchstart = () => highlightedElem.classList.remove('hidden');
+        dropmenuItem.ontouchend = () => highlightedElem.classList.add('hidden');
 
-    dropmenuItem.onmouseenter = () => highlightedElem.classList.remove('hidden');
-    dropmenuItem.onmouseleave = () => highlightedElem.classList.add('hidden');
+        dropmenuItem.onmouseenter = () => highlightedElem.classList.remove('hidden');
+        dropmenuItem.onmouseleave = () => highlightedElem.classList.add('hidden');
+    }
 
     settingsInstanceDropdownContentElem.append(dropmenuItem);
 }

--- a/app/assets/js/gui/pip.js
+++ b/app/assets/js/gui/pip.js
@@ -39,7 +39,7 @@ window.REFRESH_PIP_DISPLAY = () => {
 };
 
 async function renderPipBoards(from, to) {
-    const isNewSuggestion = pipLastPipFromTo[0] !== from && pipLastPipFromTo[1] !== to;
+    const isNewSuggestion = pipLastPipFromTo[0] !== from || pipLastPipFromTo[1] !== to;
 
     if(isNewSuggestion) {
         const cgElem = document.querySelector(`.chessground-x[data-is-latest-updated="true"]`);
@@ -112,8 +112,13 @@ async function refreshPipView() {
     let engineEvaluation = pipData?.eval;
     let progress = 0;
 
-    if(!engineEvaluation && pipLastPipEval === null) engineEvaluation = 0.5;
-    else if(engineEvaluation) pipLastPipEval = engineEvaluation;
+    if(engineEvaluation == null) {
+        // Fall back to the last known eval (or an even 0.5 on the very first refresh).
+        // Use == null so a legitimate 0 (a lost position) is treated as a real value.
+        engineEvaluation = pipLastPipEval === null ? 0.5 : pipLastPipEval;
+    } else {
+        pipLastPipEval = engineEvaluation;
+    }
     
     if((pipData.goalDepth && pipData.goalDepth < 100) || (pipData.depth === null)) {
         const depth = pipData.depth || pipData.goalDepth
@@ -140,7 +145,7 @@ async function refreshPipView() {
     }
 
     const isBoard = pipBoardInput.checked;
-    if(isBoard && bestMove) await renderPipBoards();
+    if(isBoard && bestMove) await renderPipBoards(from, to);
 
     const headerWidth = pipCanvas.width - pipEvalBarWidth;
     const noInstancesText = FULL_TRANS_OBJ?.domTranslations?.['#no-instances-title'];

--- a/app/assets/js/gui/settings.js
+++ b/app/assets/js/gui/settings.js
@@ -121,12 +121,11 @@ export async function saveSetting(settingElem, isDirectlyCausedByUser = false) {
             config[SETTING_FILTER_OBJ.type][SETTING_FILTER_OBJ.instanceID]['profiles'][profileKey][settingObj.key] = settingObj.value;
         }
     } else {
+        // Initialize the type object first so `base` is always defined
+        INIT_NESTED_OBJECT(config, [SETTING_FILTER_OBJ.type]);
         let base = config[SETTING_FILTER_OBJ.type];
-        
+
         if (noProfile) {
-            // Initialize the type object
-            INIT_NESTED_OBJECT(config, [SETTING_FILTER_OBJ.type]);
-    
             const valueToSave = settingObj.key === 'chessEngineProfile'
                 ? GET_PROFILE_STORAGE_KEY(settingObj.value)
                 : settingObj.value;
@@ -135,7 +134,7 @@ export async function saveSetting(settingElem, isDirectlyCausedByUser = false) {
         } else {
             // Initialize profiles and profileID objects
             INIT_NESTED_OBJECT(base, ['profiles', profileKey]);
-    
+
             config[SETTING_FILTER_OBJ.type]['profiles'][profileKey][settingObj.key] = settingObj.value;
         }
     }


### PR DESCRIPTION
A batch of GUI fixes found while reviewing the web app:

- `domDropdown.js`: the `doesDropdownItemExist` selector was missing its closing `]`, so `querySelector` threw a SyntaxError when saving/reading any dropdown setting (engine, weight, etc.).
- `domInputs.js`: range clamping used `... || min`, which coerced a legitimately-clamped `0` to `min`, and `if(min && max)` skipped clamping when `min === 0`. Now clamps with a `null` check and only falls back to `min` on `NaN`.
- `gui.js`: `GET_TTS_VOICES()` returns `false` when unsupported, which fell through to `.forEach` and threw every 100ms; now guarded with `!ttsVoices?.length`. Also added a null check before `closeBtn.onclick`.
- `externalEngine.js`: the "previously selected engine not available" branch (`else if(!foundSelectedEngineID ...)`) was unreachable; restructured so it actually warns. Engine-id comparisons now use `String()` consistently.
- `pip.js`: `renderPipBoards()` was called without `from/to`, so the new-suggestion dedup never matched; now passes them and uses `||`. Eval fallback now treats a real `0` as valid and falls back to the last eval instead of leaving it `undefined` (which produced `NaN`).
- `settings.js`: in the no-instance + profile branch, `base` was read before `config[type]` was initialized, so `INIT_NESTED_OBJECT` could throw; it's now initialized first.
- `dynamicEngineOptions.js`: the timeout cleanup filtered by `w.resolve !== resolve`, which never matched the stored wrapper, leaking timed-out waiters; now filters by waiter identity.
- `instances.js`: guarded `.highlight-indicator` handlers against a missing element.