### PR TITLE
fix elo skill mapping, move eval reboot, ws state and toast defaults

### DIFF
--- a/app/assets/js/AcasWebSocketClient.js
+++ b/app/assets/js/AcasWebSocketClient.js
@@ -45,6 +45,8 @@ class AcasWebSocketClient {
         };
 
         this.socket.onclose = (event) => {
+            window.wsConnectionOpen = false;
+
             const isAnyProfileUsingExternal = Object.values(IS_EXTERNAL_ENGINE_SETTING_ACTIVE)
                 .find(v => v) ? true : false;
             const shouldReconnect = isAnyProfileUsingExternal
@@ -59,10 +61,12 @@ class AcasWebSocketClient {
 
             this.reconnectionAttempts += 1;
 
-            window.wsConnectionOpen = false;
+            if(this.reconnectionAttempts < 9999) {
+                // Back off between attempts so a refused connection doesn't busy-spin.
+                const delay = Math.min(5000, this.reconnectionAttempts * 250);
 
-            if(this.reconnectionAttempts < 9999)
-                this.connect();
+                setTimeout(() => this.connect(), delay);
+            }
         };
 
         this.socket.onerror = (error) => {

--- a/app/assets/js/MoveEvaluator.js
+++ b/app/assets/js/MoveEvaluator.js
@@ -65,6 +65,10 @@ export default class MoveEvaluator {
         if(this.rebootAttempts < 3) {
             this.rebootAttempts++;
 
+            // The old worker is gone, so block eval() from posting to it until the
+            // new worker reports ready again (engineReady sets this back to true).
+            this.readyok = false;
+
             this.engine?.terminate();
             this.engine = null;
 
@@ -99,13 +103,13 @@ export default class MoveEvaluator {
     categorize(relativeCp) {
         if(relativeCp >= 250) return 7;   // Brilliancy
         if(relativeCp >= 100) return 6;   // Excellent
-        if(relativeCp >= 25) return 5;   // Good Move
-        if(relativeCp > -15 && relativeCp < 15) return 0; // Neutral
+        if(relativeCp >= 25) return 5;    // Good Move
         if(relativeCp <= -250) return 4;  // Catastrophic
         if(relativeCp <= -100) return 3;  // Blunder
-        if(relativeCp <= -25) return 2;  // Mistake
+        if(relativeCp <= -25) return 2;   // Mistake
+        if(relativeCp <= -15) return 1;   // Inaccuracy
 
-        return 1; // Inaccuracy
+        return 0; // Neutral
     }
 
     eval(moveObj, configObj, callback) {

--- a/app/assets/js/globals.js
+++ b/app/assets/js/globals.js
@@ -330,10 +330,10 @@ function GET_TTS_VOICES() {
 function GET_SKILL_FROM_ELO(elo) {
     if(elo <= 500) {
         return -20;
-    } else if(elo >= 2850) {
-        return 19;
     } else if(elo >= 2900) {
         return 20;
+    } else if(elo >= 2850) {
+        return 19;
     } else {
         const range = (elo - 500) / (2850 - 500);
 

--- a/app/assets/js/init.js
+++ b/app/assets/js/init.js
@@ -187,7 +187,17 @@ async function attemptStarting() {
         displayNoUserscriptNotification(true); // failsafe
         started = true; // failsafe
 
-        await initializeDatabase();
+        try {
+            await initializeDatabase();
+        } catch(e) {
+            // If migration fails, don't leave the app half-initialized: clear the
+            // started flag so the polling loop retries instead of giving up.
+            console.error('Database initialization failed, will retry:', e);
+            started = false;
+
+            return;
+        }
+
         initGUI();
         processUrlParams();
         startCommLink();

--- a/app/assets/js/init.js
+++ b/app/assets/js/init.js
@@ -187,7 +187,7 @@ async function attemptStarting() {
         displayNoUserscriptNotification(true); // failsafe
         started = true; // failsafe
 
-        initializeDatabase();
+        await initializeDatabase();
         initGUI();
         processUrlParams();
         startCommLink();
@@ -201,4 +201,4 @@ await attemptStarting();
 const userscriptSearchInterval = SET_INTERVAL_ASYNC(async () => {
     if(!started) await attemptStarting();
     else userscriptSearchInterval.stop();
-}, 1);
+}, 250);

--- a/app/assets/js/misc/toastMessage.js
+++ b/app/assets/js/misc/toastMessage.js
@@ -1,6 +1,9 @@
 const toast = {
     'create': (type, icon, content, duration) => {
         const intervalRate = 100;
+        // "instance" toasts are intentionally persistent; everything else defaults to 5s
+        // so a missing duration doesn't leave the toast on screen forever (NaN comparison).
+        if(duration === undefined && type !== 'instance') duration = 5000;
         const toastTotalDuration = duration;
         let toastContainer = document.querySelector('#acas-toast-container');
         let fadeTime = 500;

--- a/app/assets/js/misc/translationProcessor.js
+++ b/app/assets/js/misc/translationProcessor.js
@@ -120,6 +120,8 @@
 			const parentElement = await WAIT_FOR_ELEMENT(`[data-key="${key}"]`);
 			const customInputElem = parentElement?.closest('.custom-input');
 
+			if(!customInputElem) return;
+
 			const titleElement = customInputElem.querySelector('.input-title');
 			const subtitleElement = customInputElem.querySelector('.input-subtitle');
 

--- a/app/assets/js/misc/userSecuritySystem.js
+++ b/app/assets/js/misc/userSecuritySystem.js
@@ -22,7 +22,7 @@
                 if (tabSwitchCount >= tabSwitchThreshold) {
                     tabSwitchCount = 0;
 
-                    const msg = TRANS_OBJ?.excessiveTabChangeWarning;
+                    const msg = TRANS_OBJ?.excessiveTabChangeWarning ?? 'You are switching tabs frequently. This may look suspicious.';
                     toast.warning(msg, 25000);
                 }
 


### PR DESCRIPTION
Logic and helper fixes found while reviewing the web app:

- `globals.js` `GET_SKILL_FROM_ELO`: the `>= 2850` branch was checked before `>= 2900`, so skill level 20 was unreachable (any ELO ≥ 2900 returned 19). Reordered so the higher bound comes first.
- `MoveEvaluator.js`: `rebootEngine` terminated the worker but never reset `readyok`, so `eval()` could post to the dead worker during the reboot window; it now clears `readyok` until the new worker is ready. Also fixed `categorize` so a small positive eval gain (15–25) is `Neutral` instead of being mislabeled `Inaccuracy`.
- `AcasWebSocketClient.js`: `window.wsConnectionOpen` was only set `false` on the reconnect path, leaving stale `true` state after a non-reconnecting close; it's now set on every close. Added a small backoff between reconnect attempts instead of reconnecting immediately.
- `toastMessage.js`: `create` had no default duration, so toasts created without one never auto-closed (NaN comparison) and showed a NaN% progress bar. Non-instance toasts now default to 5s; `instance` toasts stay persistent.
- `translationProcessor.js`: `translateConfig` dereferenced the result of `WAIT_FOR_ELEMENT`/`closest` without a guard, throwing when the element wasn't found; added a null check.
- `userSecuritySystem.js`: the excessive-tab-switch warning could render the literal text "undefined" before translations loaded; added a fallback string.
- `init.js`: `initializeDatabase()` (which runs config migration) wasn't awaited before `initGUI()`, a startup race; it's now awaited. The userscript-search poll ran every 1ms; bumped to 250ms.