### PR TITLE
fix engine card refresh, remove-by-id and shutdown guards

### DIFF
--- a/appServer/backend/engine.js
+++ b/appServer/backend/engine.js
@@ -345,11 +345,13 @@ export async function addEngine(fileInfo, title = fileInfo?.name) {
     return true;
 }
 
-export function removeEngine(engineId) {
-    const index = savedEngines.findIndex(engine => String(engine.engineId) === String(engineId));
+export function removeEngine(enginePath) {
+    // path is the unique key enforced by addEngine; engineId (sha256 of the file)
+    // can collide when the same binary is added from two different paths.
+    const index = savedEngines.findIndex(engine => engine.path === enginePath);
 
     if(index === -1)
-        return `Invalid engine id: ${engineId}`;
+        return `Invalid engine path: ${enginePath}`;
 
     const savedEngineObj = savedEngines[index];
 

--- a/appServer/backend/engine.js
+++ b/appServer/backend/engine.js
@@ -17,16 +17,23 @@ export let savedEngines = store.get(chessEnginesStorageKey, []);
 let aliveEngineProcesses = [];
 let savedEngineOptions = localStoredEngineOptions || {};
 
+function sendToRenderer(channel, payload) {
+    // mainWindow may be gone during shutdown; sending to a destroyed window throws.
+    if(!mainWindow || mainWindow.isDestroyed()) return;
+
+    mainWindow.webContents.send(channel, payload);
+}
+
 export function renderEngineGrid() {
-    mainWindow.webContents.send('renderEngineGrid', { savedEngines });
+    sendToRenderer('renderEngineGrid', { savedEngines });
 }
 
 export function addConsoleView(identifierObj) {
-    mainWindow.webContents.send('addConsoleView', { identifierObj });
+    sendToRenderer('addConsoleView', { identifierObj });
 }
 
 export function removeConsoleView(identifierObj) {
-    mainWindow.webContents.send('removeConsoleView', { identifierObj });
+    sendToRenderer('removeConsoleView', { identifierObj });
 }
 
 export function refreshEngineCards(aliveEngineProcesses) {
@@ -36,11 +43,11 @@ export function refreshEngineCards(aliveEngineProcesses) {
         return safeData;
     });
 
-    mainWindow.webContents.send('refreshEngineCards', { aliveEngineProcesses: safeObjects });
+    sendToRenderer('refreshEngineCards', { aliveEngineProcesses: safeObjects });
 }
 
 export function log(text, type, identifierObj) {
-    mainWindow.webContents.send('log', { text, type, identifierObj });
+    sendToRenderer('log', { text, type, identifierObj });
 }
 
 function addAliveEngineObj(engineObj) {
@@ -85,8 +92,6 @@ function killSpecificEngine(identifierObj, code) {
 
         removeAliveEngineObj(identifierObj);
         refreshEngineCards(aliveEngineProcesses);
-        
-        removeConsoleView(identifierObj);
     }
 }
 
@@ -301,6 +306,7 @@ async function startEngineProcess(enginePath, identifierObj) {
                     sendEngineDeathCertificateToClient('Engine process closed', fen, engineId, profileName, instanceId);
 
                     removeAliveEngineObj(identifierObj);
+                    refreshEngineCards(aliveEngineProcesses);
 
                     toast('warning', `Engine ID ${engineId} closed. ${code ? '('+code+')' : ''}`, 3000);
                 });
@@ -339,9 +345,11 @@ export async function addEngine(fileInfo, title = fileInfo?.name) {
     return true;
 }
 
-export function removeEngine(index) {
-    if(!Number.isInteger(index) || index < 0 || index >= savedEngines.length)
-        return `Invalid engine index: ${index}`;
+export function removeEngine(engineId) {
+    const index = savedEngines.findIndex(engine => String(engine.engineId) === String(engineId));
+
+    if(index === -1)
+        return `Invalid engine id: ${engineId}`;
 
     const savedEngineObj = savedEngines[index];
 

--- a/appServer/backend/main.js
+++ b/appServer/backend/main.js
@@ -72,7 +72,7 @@ app.whenReady().then(() => {
 		async (event, fileInfo, title) => addEngine(fileInfo, title));
 
 	ipcMain.handle('removeEngine',
-		async (event, engineId) => removeEngine(engineId));
+		async (event, enginePath) => removeEngine(enginePath));
 	
 	ipcMain.handle('pickFile', async () => {
 		const result = await dialog.showOpenDialog(mainWindow, {

--- a/appServer/backend/main.js
+++ b/appServer/backend/main.js
@@ -72,7 +72,7 @@ app.whenReady().then(() => {
 		async (event, fileInfo, title) => addEngine(fileInfo, title));
 
 	ipcMain.handle('removeEngine',
-		async (event, index) => removeEngine(index));
+		async (event, engineId) => removeEngine(engineId));
 	
 	ipcMain.handle('pickFile', async () => {
 		const result = await dialog.showOpenDialog(mainWindow, {

--- a/appServer/backend/preload.js
+++ b/appServer/backend/preload.js
@@ -6,7 +6,7 @@ contextBridge.exposeInMainWorld('engineAPI', {
 	getSavedEngines: () => ipcRenderer.invoke('getSavedEngines'),
 	sendManualUciToEngine: (cmd, identifierObj) => ipcRenderer.invoke('sendManualUciToEngine', cmd, identifierObj),
 	addEngine: (fileInfo, title) => ipcRenderer.invoke('addEngine', fileInfo, title),
-	removeEngine: (engineId) => ipcRenderer.invoke('removeEngine', engineId),
+	removeEngine: (enginePath) => ipcRenderer.invoke('removeEngine', enginePath),
 	onRenderEngineGrid: (callback) => ipcRenderer.on('renderEngineGrid', (event, data) => callback(data)),
 	onAddConsoleView: (callback) => ipcRenderer.on('addConsoleView', (event, data) => callback(data)),
 	onRemoveConsoleView: (callback) => ipcRenderer.on('removeConsoleView', (event, data) => callback(data)),

--- a/appServer/backend/preload.js
+++ b/appServer/backend/preload.js
@@ -6,7 +6,7 @@ contextBridge.exposeInMainWorld('engineAPI', {
 	getSavedEngines: () => ipcRenderer.invoke('getSavedEngines'),
 	sendManualUciToEngine: (cmd, identifierObj) => ipcRenderer.invoke('sendManualUciToEngine', cmd, identifierObj),
 	addEngine: (fileInfo, title) => ipcRenderer.invoke('addEngine', fileInfo, title),
-	removeEngine: (index) => ipcRenderer.invoke('removeEngine', index),
+	removeEngine: (engineId) => ipcRenderer.invoke('removeEngine', engineId),
 	onRenderEngineGrid: (callback) => ipcRenderer.on('renderEngineGrid', (event, data) => callback(data)),
 	onAddConsoleView: (callback) => ipcRenderer.on('addConsoleView', (event, data) => callback(data)),
 	onRemoveConsoleView: (callback) => ipcRenderer.on('removeConsoleView', (event, data) => callback(data)),

--- a/appServer/backend/util.js
+++ b/appServer/backend/util.js
@@ -55,5 +55,7 @@ export function verifyLaunchParams(params) {
 }
 
 export function toast(type, text, ms) {
+    if(!mainWindow || mainWindow.isDestroyed()) return;
+
     mainWindow.webContents.send('toast', { type, text, ms });
 }

--- a/appServer/ui/index.js
+++ b/appServer/ui/index.js
@@ -59,11 +59,10 @@ addEngineBtn.onclick = async () => {
 };
 
 function refreshEngineCards(aliveEngineProcesses) {
-    console.log(aliveEngineProcesses);
-    const aliveIds = aliveEngineProcesses.map(ep => ep.identifierObj.engineId);
+    const aliveIds = aliveEngineProcesses.map(ep => String(ep.identifierObj.engineId));
 
     [...document.querySelectorAll('.card')]
-        .filter(x => !aliveIds.includes(Number(x.dataset.engineId || 0)))
+        .filter(x => !aliveIds.includes(x.dataset.engineId))
         .forEach(x => x.classList.remove('active'));
 }
 
@@ -75,7 +74,7 @@ async function renderEngineGrid(savedEngines) {
         if(!engineIds.includes(card.dataset.engineId)) card.remove();
     });
 
-    savedEngines.forEach((engine, index) => {
+    savedEngines.forEach(engine => {
         if(engineUiGrid.querySelector(`[data-engine-id="${engine.engineId}"]`)) return;
 
         const card = document.createElement('div');
@@ -94,7 +93,7 @@ async function renderEngineGrid(savedEngines) {
         removeBtn.onclick = async (e) => {
             e.stopPropagation();
 
-            const result = await window.engineAPI.removeEngine(index);
+            const result = await window.engineAPI.removeEngine(engine.engineId);
 
             if(typeof result === 'string') toast.error(result, 5000);
         };

--- a/appServer/ui/index.js
+++ b/appServer/ui/index.js
@@ -93,7 +93,7 @@ async function renderEngineGrid(savedEngines) {
         removeBtn.onclick = async (e) => {
             e.stopPropagation();
 
-            const result = await window.engineAPI.removeEngine(engine.engineId);
+            const result = await window.engineAPI.removeEngine(engine.path);
 
             if(typeof result === 'string') toast.error(result, 5000);
         };


### PR DESCRIPTION
appServer (Electron + engine server) fixes:

- `ui/index.js` `refreshEngineCards`: engine ids are sha256 hex strings, but cards were compared via `Number(...)` which is always `NaN`, so `active` was removed from every card regardless of which engines were alive. Now compares as strings. Also dropped a leftover `console.log`.
- Engine removal used a positional `index` captured in the card's click handler, but `renderEngineGrid` only appends new cards, so after a removal (which splices the array) surviving cards kept stale indices and could remove the wrong engine. `removeEngine` now takes an `engineId` and looks up the current index itself (`engine.js`, `main.js`, `preload.js`, `ui/index.js`).
- `engine.js`: the `close` handler (engine self-terminating) removed the alive engine object but never called `refreshEngineCards`, so the card stayed "active"; it now refreshes. Removed a duplicate `removeConsoleView` call in `killSpecificEngine`.
- `engine.js` / `util.js`: the renderer-send helpers (`renderEngineGrid`, `addConsoleView`, `removeConsoleView`, `refreshEngineCards`, `log`, `toast`) dereferenced `mainWindow.webContents` with no guard and could throw during shutdown when engines close. They now go through a guarded helper that checks `mainWindow.isDestroyed()`.