### PR TITLE
fix: emit 'bestmove (none)' on terminal positions

### DIFF
--- a/app/assets/engines/Maia3/maiaEngine.js
+++ b/app/assets/engines/Maia3/maiaEngine.js
@@ -103,7 +103,10 @@ class MaiaEngine {
 					moves = moves.filter(m => set.has(m));
 				}
 
-				if(moves.length === 0) return;
+				if(moves.length === 0) {
+					this.listen('bestmove (none)');
+					break;
+				}
 
 				for(let i = 0; i < Math.min(this.options.multipv, moves.length); i++) {
 					const move = moves[i];


### PR DESCRIPTION
- `maiaEngine.js`: `go` handler returned without a `bestmove` when there were no legal moves (checkmate/stalemate, or `searchmoves` filtered everything out), hanging the A.C.A.S profile forever. Now emits `bestmove (none)`, matching Maia 2.