### PR TITLE
fix castling/en passant move detection and variant board sizes

### DIFF
--- a/app/assets/js/BoardAnalyzer.js
+++ b/app/assets/js/BoardAnalyzer.js
@@ -42,7 +42,9 @@ export default class BoardAnalyzer {
     }
 
     flipFen() {
-        const firstSpace = this.fen.indexOf(' ');
+        const spaceIndex = this.fen.indexOf(' ');
+        // A board-only FEN has no fields after it, so keep the whole string
+        const firstSpace = spaceIndex === -1 ? this.fen.length : spaceIndex;
         const board = this.fen.slice(0, firstSpace);
 
         const flippedBoard = board.split('/')
@@ -64,11 +66,12 @@ export default class BoardAnalyzer {
             const row = [];
             const rowString = rows[i];
 
-            for(let char of rowString) {
-                if(parseInt(char))
-                    row.push(...Array(parseInt(char)).fill(null));
+            // Digit runs, so "10" empty squares on a wide board stays 10 and not 1
+            for(const token of rowString.match(/\d+|\D/g) ?? []) {
+                if(isNaN(token))
+                    row.push(token);
                 else
-                    row.push(char);
+                    row.push(...Array(parseInt(token, 10)).fill(null));
             }
 
             // Ensure that the board has a consistent number of columns

--- a/app/assets/js/globals.js
+++ b/app/assets/js/globals.js
@@ -488,13 +488,16 @@ function FEN_TO_ARRAYS(fen) {
 
     for(let row of rows) {
         const boardRow = [];
-        for(let char of row) {
-            if(isNaN(char)) {
-                boardRow.push(char);
+
+        // Match digit runs, not single digits, so wide boards ("10" empty squares) don't collapse
+        for(const token of row.match(/\d+|\D/g) ?? []) {
+            if(isNaN(token)) {
+                boardRow.push(token);
             } else {
-                boardRow.push(...Array(parseInt(char)).fill(''));
+                boardRow.push(...Array(parseInt(token, 10)).fill(''));
             }
         }
+
         board.push(boardRow);
     }
 
@@ -508,14 +511,15 @@ function IS_PLAYER_ATTACKING_KING(currentFen, turn) {
     const rows = boardPart.split('/');
     const board = [];
 
-    for(let i = 0; i < 8; i++) {
+    // Variant boards are not always 8x8, so follow the FEN instead of assuming
+    for(const rowString of rows) {
         const row = [];
 
-        for(let char of rows[i]) {
-            if(isNaN(char)) {
-                row.push(char);
+        for(const token of rowString.match(/\d+|\D/g) ?? []) {
+            if(isNaN(token)) {
+                row.push(token);
             } else {
-                for(let j = 0; j < parseInt(char); j++) row.push(1);
+                for(let j = 0; j < parseInt(token, 10); j++) row.push(1);
             }
         }
 
@@ -525,10 +529,13 @@ function IS_PLAYER_ATTACKING_KING(currentFen, turn) {
     const isWhiteAttacking = turn === 'w';
     const enemyKing = isWhiteAttacking ? 'k' : 'K';
 
+    const boardHeight = board.length;
+    const boardWidth = board.reduce((max, row) => Math.max(max, row.length), 0);
+
     let kX = -1, kY = -1;
-    
-    for(let y = 0; y < 8; y++) {
-        for(let x = 0; x < 8; x++) {
+
+    for(let y = 0; y < boardHeight; y++) {
+        for(let x = 0; x < board[y].length; x++) {
             if(board[y][x] === enemyKing) { kX = x; kY = y; break; }
         }
         if(kX !== -1) break;
@@ -542,18 +549,19 @@ function IS_PLAYER_ATTACKING_KING(currentFen, turn) {
 
     const kn = [[-2, -1], [-2, 1], [-1, -2], [-1, 2], [1, -2], [1, 2], [2, -1], [2, 1]];
 
-    for(let i = 0; i < 8; i++) {
+    for(let i = 0; i < kn.length; i++) {
         const p = board[kY + kn[i][1]]?.[kX + kn[i][0]];
         if(p === atk.n) return true;
     }
 
     const dirs = [[0, -1], [0, 1], [-1, 0], [1, 0], [1, -1], [-1, -1], [1, 1], [-1, 1]];
+    const maxRayLength = Math.max(boardWidth, boardHeight);
 
-    for(let i = 0; i < 8; i++) {
+    for(let i = 0; i < dirs.length; i++) {
         const dx = dirs[i][0], dy = dirs[i][1];
         const isDiagonal = i > 3;
 
-        for(let j = 1; j < 8; j++) {
+        for(let j = 1; j < maxRayLength; j++) {
             const x = kX + dx * j, y = kY + dy * j;
             const p = board[y]?.[x];
             if(p === undefined) break;
@@ -772,18 +780,43 @@ function EXTRACT_MOVE_FROM_FEN(lastFen, currentFen, boardDimensions = [8, 8]) {
     let moveTo = null;
     let movedPiece = null;
 
+    // Castling and en passant change more than two squares, so collect every change
+    // first instead of letting the last one seen win.
+    const vacated = [];
+    const filled = [];
+
     for(let i = 0; i < rows; i++) {
         for(let j = 0; j < cols; j++) {
-            if(lastBoard[i][j] !== currentBoard[i][j]) {
-                if(lastBoard[i][j] !== '' && currentBoard[i][j] === '') {
-                    moveFrom = `${String.fromCharCode(97 + j)}${rows - i}`;
-                }
-                if(currentBoard[i][j] !== '') {
-                    moveTo = `${String.fromCharCode(97 + j)}${rows - i}`;
-                    movedPiece = currentBoard[i][j];
-                }
+            if(lastBoard[i]?.[j] === currentBoard[i]?.[j]) continue;
+
+            const square = `${String.fromCharCode(97 + j)}${rows - i}`;
+
+            if(lastBoard[i][j] !== '' && currentBoard[i][j] === '') {
+                vacated.push({ square, 'piece': lastBoard[i][j] });
+            }
+            if(currentBoard[i][j] !== '') {
+                filled.push({ square, 'piece': currentBoard[i][j] });
             }
         }
+    }
+
+    // Castling fills two squares; the king is the piece that identifies the move.
+    const kingTo = filled.find(sq => sq.piece.toLowerCase() === 'k');
+    const kingFrom = vacated.find(sq => sq.piece.toLowerCase() === 'k');
+
+    const to = (kingTo && kingFrom) ? kingTo : filled[0];
+
+    if(to) {
+        moveTo = to.square;
+        movedPiece = to.piece;
+
+        // The origin is the square that held this very piece. For en passant that
+        // separates the capturing pawn from the captured one; for a promotion no
+        // square matches, so fall back to the only square that was vacated.
+        const from = vacated.find(sq => sq.piece === to.piece)
+            ?? (vacated.length === 1 ? vacated[0] : null);
+
+        moveFrom = from?.square ?? null;
     }
 
     let color = movedPiece ? (movedPiece === movedPiece.toUpperCase() ? 'w' : 'b') : null;

--- a/app/assets/js/instance/Interface.js
+++ b/app/assets/js/instance/Interface.js
@@ -163,7 +163,9 @@ export default class Interface {
     }
     
     async updateBoardFen(fen) {
-        const moveObj = EXTRACT_MOVE_FROM_FEN(this.AcasInstance.currentFen, fen);
+        const instanceDimensions = this.AcasInstance.boardDimensions;
+        const moveObj = EXTRACT_MOVE_FROM_FEN(this.AcasInstance.currentFen, fen,
+            [instanceDimensions.width, instanceDimensions.height]);
         const movedPieceLowered = moveObj?.movedPiece?.toLowerCase();
         const instanceFenElem = this?.AcasInstance?.instanceElem?.querySelector('.instance-fen');
 

--- a/app/assets/js/instance/renderFeedback.js
+++ b/app/assets/js/instance/renderFeedback.js
@@ -71,7 +71,8 @@ export default async function renderFeedback(currentFen) {
         const playerColor = await this.getPlayerColor();
 
         if(isChangeLogical && lastFen && currentFen) {
-            const moveObj = EXTRACT_MOVE_FROM_FEN(lastFen, currentFen);
+            const moveObj = EXTRACT_MOVE_FROM_FEN(lastFen, currentFen,
+                [this.boardDimensions.width, this.boardDimensions.height]);
             const from = moveObj.from,
                   to = moveObj.to,
                   pieceColor = moveObj.color;

--- a/app/assets/js/instance/setupEnvironment.js
+++ b/app/assets/js/instance/setupEnvironment.js
@@ -55,6 +55,10 @@ export default async function setupEnvironment(startpos, dimensions) {
         const orientation = await this.getPlayerColor();
 
         const boardDimensions = { 'width': dimensions[0], 'height': dimensions[1] };
+
+        // Keep the instance in sync, it still held the 8x8 default otherwise
+        this.boardDimensions = boardDimensions;
+
         const instanceIdQuery = `[data-instance-id="${this.instanceID}"]`;
 
         this.currentFen = fen;


### PR DESCRIPTION
EXTRACT_MOVE_FROM_FEN let the last changed square win, so O-O-O reported movedPiece=R instead of the king. updateBoardFen only bumps kingMoved for a king, so castling queenside left KQ in the FEN for the rest of the game. Black en passant returned the captured pawn’s square as from, and renderFeedback then searchmoves an illegal move.

Collects the vacated/filled squares first now and picks the king when one both left and arrived, otherwise matches the origin by piece.

Also: digit runs in FEN_TO_ARRAYS/parseFEN (10 empty squares parsed as 1), flipFen on a board-only FEN, IS_PLAYER_ATTACKING_KING threw on boards smaller than 8x8, and AcasInstance.boardDimensions was initialised to 8x8 and never updated.