### PR TITLE
catch async command rejections and add missing socket error handlers

### DIFF
--- a/appServer/backend/engine.js
+++ b/appServer/backend/engine.js
@@ -210,7 +210,16 @@ export function sendToProcess(cmd, identifierObj, type = 'user') {
     const { engineProcess } = engineObj;
 
     if(engineProcess.stdin.writable) {
-        engineProcess.stdin.write(cmd + '\n', 'utf8');
+        // writable stays true for a moment after the child dies, and an unhandled
+        // stream error (EPIPE) would take the whole app down with every other engine
+        try {
+            engineProcess.stdin.write(cmd + '\n', 'utf8', err => {
+                if(err) console.error(`[engine] failed writing to engine stdin: ${err.message}`);
+            });
+        } catch (err) {
+            console.error(`[engine] failed writing to engine stdin: ${err.message}`);
+            return;
+        }
 
         log(cmd, type, identifierObj);
     }
@@ -292,6 +301,11 @@ async function startEngineProcess(enginePath, identifierObj) {
                 });
 
                 engineProcess.stderr.on('data', (data) => log(`${data}`, 'info', identifierObj));
+
+                // Streams throw on an unhandled 'error', which kills the main process
+                for(const stream of [engineProcess.stdin, engineProcess.stdout, engineProcess.stderr]) {
+                    stream?.on('error', err => console.error(`[engine] stream error: ${err?.message}`));
+                }
 
                 engineProcess.on('error', (err) => {
                     clearTimeout(launchTimeout);

--- a/appServer/backend/main.js
+++ b/appServer/backend/main.js
@@ -49,6 +49,19 @@ function createWindow() {
 	return win;
 }
 
+// Two copies fighting over port 2800 just means the second one has no working server
+if(!app.requestSingleInstanceLock()) {
+	app.quit();
+}
+
+app.on('second-instance', () => {
+	if(!mainWindow || mainWindow.isDestroyed()) return;
+
+	if(mainWindow.isMinimized()) mainWindow.restore();
+
+	mainWindow.focus();
+});
+
 app.whenReady().then(() => {
 	mainWindow = createWindow();
 	mainWindow.setMenu(null);

--- a/appServer/backend/server.js
+++ b/appServer/backend/server.js
@@ -105,7 +105,9 @@ function onCommandReceived(remoteCommand) {
 
         switch (type) {
             case 'uci':
-                handleClientUciCommand(msg);
+                // Async, so its throws land as rejections that this try/catch can't see.
+                // Every input validation in handleClientUciCommand went unreported before.
+                handleClientUciCommand(msg).catch(e => reportCommandFailure(remoteCommand, e));
                 break;
 
             case 'getEngines':
@@ -123,8 +125,12 @@ function onCommandReceived(remoteCommand) {
         }
 
     } catch (e) {
-        toast('error', `Failed to process remote command;\n\n${remoteCommand?.slice(0, 500)}\n\nReason: ${e?.message}`, 20000);
+        reportCommandFailure(remoteCommand, e);
     }
+}
+
+function reportCommandFailure(remoteCommand, e) {
+    toast('error', `Failed to process remote command;\n\n${remoteCommand?.slice(0, 500)}\n\nReason: ${e?.message}`, 20000);
 }
 
 export function startLocalWSS() {
@@ -165,7 +171,15 @@ export function startLocalWSS() {
 
             if(wss.onClientChange) wss.onClientChange(false);
         });
+
+        // ws requires this, without it a client resetting mid-frame throws
+        ws.on('error', err => {
+            console.error('[server] client socket error:', err?.message);
+            clients.delete(ws);
+        });
     });
+
+    wss.on('error', err => console.error('[server] websocket server error:', err?.message));
 
     wss.httpServer.on('listening', () => {
         if(!mainWindow || mainWindow.isDestroyed()) return;
@@ -195,6 +209,17 @@ export function startLocalWSS() {
             origin
         });
     };
+
+    // Emitted asynchronously, so with no listener EADDRINUSE takes the process down
+    // and the window is left showing OFFLINE forever
+    server.on('error', err => {
+        const reason = err?.code === 'EADDRINUSE'
+            ? `Port ${PORT} is already in use, is another copy of ACAS running?`
+            : `Server error: ${err?.message}`;
+
+        console.error('[server]', reason);
+        toast('error', reason, 20000);
+    });
 
     server.listen(PORT, '127.0.0.1');
 


### PR DESCRIPTION
onCommandReceived wraps handleClientUciCommand in try/catch but doesn’t await it. It’s async, so every throw is a rejected promise the catch can’t see - all the input validation in it was unreachable and the toast was dead code. There’s no unhandledRejection handler either, so {"type":"uci","msg":{"engineId":12345}} gets you a crash dialog instead. That’s the shape the function’s own doc comment shows.

Also adds the missing error listeners: the http server (EADDRINUSE threw and left the port display stuck on OFFLINE), per-connection ws errors, and the engine’s stdio - stdin.writable stays true for a moment after the child dies, so writing to an engine that just crashed raised EPIPE and took the app down with every other engine. Plus a single instance lock.