### PR TITLE
guard profiles without a loaded engine and restore dropped error handling

### DIFF
--- a/app/assets/js/AcasInstance.js
+++ b/app/assets/js/AcasInstance.js
@@ -916,7 +916,10 @@ export default class AcasInstance {
             }
         } else if(typeof i === 'number') {
             if(i >= 0 && i < this.engines.length) {
-                const profileName = this.engines[i].profile;
+                // Engine objects are built with profileName, not profile. This was always
+                // undefined, so pV[undefined] was falsy and closing an instance left its
+                // markings on the board and the whole pV map in memory.
+                const profileName = this.engines[i].profileName;
 
                 this.engines[i].worker?.terminate();
                 delete this.engines[i].worker;

--- a/app/assets/js/globals.js
+++ b/app/assets/js/globals.js
@@ -31,9 +31,17 @@ const DYNAMIC_BUTTONPRESS_BROADCAST_NAME = 'dynamicSettingButtonFeed';
 const SETTING_FILTER_OBJ = { 'type': 'global', 'instanceID': null, 'profileID': null };
 
 const EE_ACTIVE_STORAGE_KEY = 'IS_EXTERNAL_ENGINE_SETTING_ACTIVE';
-const IS_EXTERNAL_ENGINE_SETTING_ACTIVE = JSON.parse(
-    localStorage.getItem(EE_ACTIVE_STORAGE_KEY) || "{}"
-);
+// Top level in a plain script every other file depends on, so a corrupt value (or a
+// context where localStorage itself throws) took the whole app down before it rendered,
+// and it stayed down on every reload until storage was cleared by hand.
+const IS_EXTERNAL_ENGINE_SETTING_ACTIVE = (() => {
+    try {
+        return JSON.parse(localStorage.getItem(EE_ACTIVE_STORAGE_KEY) || "{}") ?? {};
+    } catch(e) {
+        console.warn('Could not read stored external engine state, starting fresh:', e?.message);
+        return {};
+    }
+})();
 
 const FI_NUMBER_FORMATTER = new Intl.NumberFormat('fi-FI');
 const ACTIVE_INPUT_LISTENERS = [];

--- a/app/assets/js/gui/domDropdown.js
+++ b/app/assets/js/gui/domDropdown.js
@@ -1,5 +1,9 @@
 export function doesDropdownItemExist(dropdownInputElem, itemValue) {
-    return dropdownInputElem.parentElement.querySelector(`*[data-value="${itemValue}"]`) ? true : false;
+    // itemValue is whatever the user typed into the dropdown filter, so a single quote
+    // character used to throw SyntaxError straight out of getInputValue
+    const selector = `*[data-value=${CSS.escape(String(itemValue))}]`;
+
+    return dropdownInputElem.parentElement.querySelector(selector) ? true : false;
 }
 
 export function addDropdownItem(dropdownElem, itemValue, itemText) {

--- a/app/assets/js/gui/dynamicEngineOptions.js
+++ b/app/assets/js/gui/dynamicEngineOptions.js
@@ -97,7 +97,21 @@ export function ensureOneDynamicEngineSettingVisible(engineId) {
 }
 
 export async function fillDynamicEngineOptionContainer(uciMsg, profileName) {
-    let { name, type, def, min, max, vars } = PARSE_UCI_OPTION(uciMsg);
+    // PARSE_UCI_OPTION returns null for a line with no type token and throws on
+    // over-long ones. The caller doesn't await this, so either used to escape as an
+    // unhandled rejection and leave the settings panel half built.
+    let parsedOption = null;
+
+    try {
+        parsedOption = PARSE_UCI_OPTION(uciMsg);
+    } catch(e) {
+        console.warn('Skipping unparsable UCI option:', uciMsg, e?.message);
+        return;
+    }
+
+    if(!parsedOption?.name) return;
+
+    let { name, type, def, min, max, vars } = parsedOption;
     const currentEngineId = await GET_ACTIVE_ENGINE_NAME(profileName);
     const dbKey = getDynamicEngineDbKeyPrefix(currentEngineId) + name.replaceAll(' ', '-');
 
@@ -170,7 +184,9 @@ export async function fillDynamicEngineOptionContainer(uciMsg, profileName) {
 
                 input.dataset.spin = true;
 
-                if(min && max) {
+                // A spin option can legitimately start at 0, which is falsy and used to
+                // drop both the clamp and the range label
+                if(min != null && max != null) {
                     input.dataset.between = `${min}-${max}`;
                     title.innerText = title.innerText + ` (${min} - ${max})`;
                 }
@@ -208,7 +224,8 @@ export async function fillDynamicEngineOptionContainer(uciMsg, profileName) {
                 dropdownContainer.appendChild(dropdownIcon);
                 dropdownContainer.appendChild(dropdownListContainer);
 
-                vars.forEach(v => {
+                // A combo option without any var tokens leaves vars undefined
+                (vars ?? []).forEach(v => {
                     dropdownListContainer.appendChild(createDropdownItem(v.replaceAll(' ', '')));
                 });
 

--- a/app/assets/js/instance/engineMessageProcessor.js
+++ b/app/assets/js/instance/engineMessageProcessor.js
@@ -89,10 +89,12 @@ export default async function engineMessageProcessor(msg, profile) {
                 updatePipData({ 'depth': data?.depth, 'mate': data?.mate });
             }
 
-            if(data?.cp)
+            // A dead even score is 0, which is falsy, so the eval bar used to keep showing
+            // the previous advantage whenever the engine found an equalisation
+            if(data?.cp != null)
                 this.Interface.updateEval(data.cp, false, profile);
 
-            if(data?.mate) 
+            if(data?.mate != null)
                 this.Interface.updateEval(data.mate, true, profile);
         }
     }

--- a/app/assets/js/instance/engineStartNewGame.js
+++ b/app/assets/js/instance/engineStartNewGame.js
@@ -12,14 +12,20 @@ async function startWithBasicOptions(variant, engineName, profile) {
 }
 
 async function startWithDynamicOptions(variant, engineName, profile) {
-    await onDynamicOptionsReady(profile) //.catch(err => toast.error(`onDynamicOptionsReady failed: "${err.message}"`, 5000));
-    
+    // This rejects after a 5s timeout. With the catch commented out the rejection escaped
+    // all the way past loadEngine's await, so calculateBestMoves was never reached and the
+    // profile sat there with a loaded engine that analysed nothing.
+    await onDynamicOptionsReady(profile)
+        .catch(err => toast.warning(`Engine options timed out: "${err.message}"`, 5000));
+
+
     const advancedEloDepth = await this.getConfigValue(this.configKeys.advancedEloDepth, profile);
     const engineNodes = await this.getConfigValue(this.configKeys.engineNodes, profile);
     const allSavedOptions = await GET_GM_VALUES_STARTS_WITH('DYNAMIC_', this.instanceID, profile);
     const isExternal = IS_EXTERNAL_ENGINE_SETTING_ACTIVE[profile];
 
-    if(engineName === 'lc0' && !isExternal && this.pV[profile].lc0WeightName.includes('maia') && engineNodes > 1) {
+    // lc0WeightName is null when no weight is picked yet, which threw before reaching the toast
+    if(engineName === 'lc0' && !isExternal && this.pV[profile]?.lc0WeightName?.includes('maia') && engineNodes > 1) {
         const msg = TRANS_OBJ?.maiaNodeWarning ?? 'Maia weights work best with no search, please only use one (1) search node!';
         toast.warning(msg, 5000);
     }

--- a/app/assets/js/instance/renderFeedback.js
+++ b/app/assets/js/instance/renderFeedback.js
@@ -28,6 +28,8 @@ export default async function renderFeedback(currentFen) {
             addText(to, 1.7, emoji, `opacity: 1;`, [0.8, 0.8]);
         }
 
+        if(!this.pV[profileName]) return;
+
         this.pV[profileName].activeFeedbackDisplays.push(...addedFeedbacks);
 
         if(feedbackOnExternalSite) {
@@ -62,6 +64,12 @@ export default async function renderFeedback(currentFen) {
     // Display new feedback
     for(const profileObj of profiles.filter(p => p.config.enableMoveRatings || p.config.enableEnemyFeedback)) {
         const profileName = profileObj.name;
+
+        // GET_PROFILES() returns every configured profile, but pV only holds the ones
+        // whose engine actually loaded. A profile with the engine off and move ratings
+        // on used to throw here and kill feedback for every other profile too.
+        if(!this.pV[profileName]) continue;
+
         const lastFen = this.pV[profileName].lastFen;
         const feedbackEngineDepth = await this.getConfigValue(this.configKeys.feedbackEngineDepth, profileName);
         const enablePlayerFeedback = await this.getConfigValue(this.configKeys.enableMoveRatings, profileName);

--- a/app/assets/js/instance/updateSettings.js
+++ b/app/assets/js/instance/updateSettings.js
@@ -52,8 +52,13 @@ export default async function updateSettings(updateObj) {
     const didUpdateSearchNodes = findSetting(this.configKeys.engineNodes);
 
     if(didUpdateVariant || didUpdate960Mode) {
-        this.set960Mode(useChess960, profileName);
-        this.engineStartNewGame(didUpdateVariant ? chessVariant : this.pV[profileName].chessVariant, profileName);
+        // Both of these reach into this.pV[profileName]. A profile whose engine is off was
+        // never loaded so it has no entry, and the disabled-profile loop above only bails
+        // out when one exists.
+        if(this.pV[profileName]) {
+            this.set960Mode(useChess960, profileName);
+            this.engineStartNewGame(didUpdateVariant ? chessVariant : this.pV[profileName].chessVariant, profileName);
+        }
 
         return;
     }
@@ -76,7 +81,10 @@ export default async function updateSettings(updateObj) {
     }
 
     if(didUpdateAdvancedElo) {
-        this.updateAdvancedModeStatus(profileName, settingValue);
+        // createAndLoadSpecificEngine builds the pV entry itself, so only the status
+        // update needs an existing one
+        if(this.pV[profileName]) this.updateAdvancedModeStatus(profileName, settingValue);
+
         this.createAndLoadSpecificEngine(profileName);
     }
 
@@ -97,12 +105,13 @@ export default async function updateSettings(updateObj) {
     if(didUpdateElo)
         this.setEngineElo(await this.getConfigValue(this.configKeys.engineElo, profileName), isDirectlyCausedByUser, profileName);
 
-    if(didUpdateAdvancedEloDepth) {
+    if(didUpdateAdvancedEloDepth && this.pV[profileName]) {
         this.pV[profileName].searchDepth = settingValue;
     }
 
     if(didUpdateSearchNodes) {
-        this.pV[profileName].engineNodes = settingValue;
+        if(this.pV[profileName]) this.pV[profileName].engineNodes = settingValue;
+
         updatePipData({ 'goalDepth': null });
     }
 


### PR DESCRIPTION
GET_PROFILES() returns every configured profile but pV only holds the ones whose engine loaded. A profile with the engine off and move ratings on throws in renderFeedback, and since the loop aborts, feedback dies for every profile - swallowed as an unhandled rejection. clearFeedback right above it already guards this way. Same thing in updateSettings. Guards are targeted rather than one early return, because the engineEnabled path is how a profile loads its engine the first time.

Also: onDynamicOptionsReady’s .catch was commented out and its 5s rejection escaped past loadEngine’s await, so calculateBestMoves never ran and the profile sat there analysing nothing; PARSE_UCI_OPTION’s result was destructured unguarded; killEngine read .profile where engine objects use .profileName; if(data?.cp) dropped a 0.00 eval; dropdown filter text went into querySelector unescaped; and the top-level JSON.parse of localStorage in globals.js could take the whole app down before it rendered.