### PR TITLE
clear engine load intervals, destroy boards and disconnect observers

### DIFF
--- a/app/assets/js/AcasInstance.js
+++ b/app/assets/js/AcasInstance.js
@@ -967,6 +967,22 @@ export default class AcasInstance {
 
         this?.killEngines();
 
+        // Engines still in their load handshake are not in this.engines yet, so killEngines
+        // can't reach them and both the worker and its poller would outlive the instance
+        this.pendingEngineLoads?.forEach(entry => {
+            clearInterval(entry.intervalId);
+            entry.worker?.terminate?.();
+        });
+        this.pendingEngineLoads?.clear();
+
+        this.boardResizeObserver?.disconnect();
+        this.boardResizeObserver = null;
+
+        // Chessground binds scroll/resize listeners on document and window; without
+        // destroy() every opened and closed instance leaks them plus the whole board state
+        this.chessground?.destroy?.();
+        this.chessground = null;
+
         this?.CommLink?.kill();
 
         if(this.MoveEval) {

--- a/app/assets/js/gui/pip.js
+++ b/app/assets/js/gui/pip.js
@@ -14,6 +14,8 @@ let pipCanvas = null;
 let pipLastPipEval = null;
 let pipLastPipFromTo = [null, null];
 let pipLastPipBoardBitmaps = [null, null];
+const PIP_CONTEXT_QUEUE_LIMIT = 30;
+
 let pipContextQueue = [];
 let pipProcessingBestMove = false;
 let pipRefreshTimeout = null;
@@ -281,6 +283,11 @@ async function refreshPipView() {
     ctxQueue.push(['fillRect', [0, pipHeaderHeight - pipStatusBarHeight, headerWidth, pipStatusBarHeight]]);
 
     pipContextQueue.unshift(ctxQueue);
+
+    // The queue was only emptied once a bestmove arrived. During a long search
+    // updatePipData fires on every info line, so it grew for the whole session.
+    if(pipContextQueue.length > PIP_CONTEXT_QUEUE_LIMIT)
+        pipContextQueue.length = PIP_CONTEXT_QUEUE_LIMIT;
 
     if(from && to) pipLastPipFromTo = [from, to];
 

--- a/app/assets/js/instance/Interface.js
+++ b/app/assets/js/instance/Interface.js
@@ -57,11 +57,22 @@ export default class Interface {
     
         const fillSquare = (square, style) => BoardDrawer.createShape('rectangle', square, {style});
     
+        // Collected so removeMarkingFromProfile can drop them. They used to be registered
+        // once per marking and never removed, and UniversalBoardDrawer walks that array on
+        // every pointer move over a square, so a long game left hundreds of stale callbacks
+        // writing to detached nodes.
+        const squareListeners = [];
+
         const handleOpponentDisplay = (square, elem) => {
+            // createShape returns false when the drawer is terminated or the square is
+            // invalid. The old guard was missing a return, so it fell through to false.style.
+            if(!elem) return;
+
             const listener = BoardDrawer.addSquareListener(square, type => {
-                if(!elem) listener.remove();
                 elem.style.display = type === 'enter' ? 'inherit' : 'none';
             });
+
+            squareListeners.push(listener);
         };
     
         moveObjArr.forEach((mObj, idx) => {
@@ -137,6 +148,7 @@ export default class Interface {
             }
         });
     
+        this.AcasInstance.pV[profile].activeSquareListeners = squareListeners;
         this.AcasInstance.pV[profile].pastMoveObjects = [];
     }
     
@@ -147,6 +159,8 @@ export default class Interface {
             markingObj?.otherElems?.forEach(x => x?.remove());
         });
 
+        this.AcasInstance.pV[p].activeSquareListeners?.forEach(listener => listener?.remove?.());
+        this.AcasInstance.pV[p].activeSquareListeners = [];
         this.AcasInstance.pV[p].activeGuiMoveMarkings = [];
     }
 

--- a/app/assets/js/instance/loadEngine.js
+++ b/app/assets/js/instance/loadEngine.js
@@ -28,8 +28,41 @@ export default async function loadEngine(profileName, engineName, attempt = 0) {
         }
     };
 
-    function restartEngine(name, e) {
+    // Load pollers were cleared only when the engine reported back. If the worker failed
+    // to load instead, the interval kept posting to it at 10Hz for the life of the page
+    // and the worker was never terminated, because it only reaches this.engines on the
+    // successful handshake.
+    this.pendingEngineLoads ??= new Set();
+
+    const trackLoad = (worker, intervalId) => {
+        const entry = { worker, intervalId };
+
+        this.pendingEngineLoads.add(entry);
+
+        return entry;
+    };
+
+    const finishLoad = entry => {
+        if(!entry) return;
+
+        clearInterval(entry.intervalId);
+        this.pendingEngineLoads.delete(entry);
+    };
+
+    const abandonLoad = entry => {
+        if(!entry) return;
+
+        clearInterval(entry.intervalId);
+        entry.worker?.terminate?.();
+        this.pendingEngineLoads.delete(entry);
+    };
+
+    function restartEngine(name, e, loadEntry) {
+        abandonLoad(loadEntry);
+
+        // This guard was dead, the flag was never set, so every onerror re-closed the instance
         if(alreadyRestarted) return;
+        alreadyRestarted = true;
 
         setProfileBubbleStatus('warning', profileName, `Restarting the instance due to the error: ${e?.message}`);
         console.error(`Restarting the instance "${name}" due to the error:`, e);
@@ -96,17 +129,17 @@ export default async function loadEngine(profileName, engineName, attempt = 0) {
             }
         };
 
-        const waitStockfish = setInterval(() => {
+        const loadEntry = trackLoad(stockfish, setInterval(() => {
             if(stockfish_loaded) {
-                clearInterval(waitStockfish);
+                finishLoad(loadEntry);
                 return;
             }
 
             stockfish.postMessage({ method: 'acas_check_loaded' });
-        }, 100);
+        }, 100));
 
         stockfish.onerror = e => {
-            restartEngine.bind(this)('fairy-stockfish-nnue-wasm', e);
+            restartEngine.bind(this)('fairy-stockfish-nnue-wasm', e, loadEntry);
         };
     }
 
@@ -132,17 +165,17 @@ export default async function loadEngine(profileName, engineName, attempt = 0) {
             }
         };
 
-        const waitStockfish = setInterval(() => {
+        const loadEntry = trackLoad(stockfish, setInterval(() => {
             if(stockfish_loaded) {
-                clearInterval(waitStockfish);
+                finishLoad(loadEntry);
                 return;
             }
 
             stockfish.postMessage({ method: 'acas_check_loaded' });
-        }, 100);
+        }, 100));
 
         stockfish.onerror = e => {
-            restartEngine.bind(this)(engineName, e);
+            restartEngine.bind(this)(engineName, e, loadEntry);
         };
     }
 
@@ -170,17 +203,17 @@ export default async function loadEngine(profileName, engineName, attempt = 0) {
             }
         };
 
-        const waitLc0 = setInterval(() => {
+        const loadEntry = trackLoad(lc0, setInterval(() => {
             if(lc0_loaded) {
-                clearInterval(waitLc0);
+                finishLoad(loadEntry);
                 return;
             }
 
             lc0.postMessage({ method: 'acas_check_loaded' });
-        }, 100);
+        }, 100));
 
         lc0.onerror = e => {
-            restartEngine.bind(this)('lc0', e);
+            restartEngine.bind(this)('lc0', e, loadEntry);
         };
     }
 
@@ -206,17 +239,17 @@ export default async function loadEngine(profileName, engineName, attempt = 0) {
             }
         };
 
-        const waitFusion = setInterval(() => {
+        const loadEntry = trackLoad(Fusion, setInterval(() => {
             if(fusion_loaded) {
-                clearInterval(waitFusion);
+                finishLoad(loadEntry);
                 return;
             }
 
             Fusion.postMessage({ method: 'acas_check_loaded' });
-        }, 100);
+        }, 100));
 
         Fusion.onerror = e => {
-            restartEngine.bind(this)('acas-fusion', e);
+            restartEngine.bind(this)('acas-fusion', e, loadEntry);
         };
     }
 
@@ -286,17 +319,17 @@ export default async function loadEngine(profileName, engineName, attempt = 0) {
             }
         };
 
-        const waitMaia = setInterval(() => {
+        const loadEntry = trackLoad(maia, setInterval(() => {
             if(maia_loaded) {
-                clearInterval(waitMaia);
+                finishLoad(loadEntry);
                 return;
             }
 
             maia.postMessage({ method: 'acas_check_loaded' });
-        }, 100);
+        }, 100));
 
         maia.onerror = e => {
-            restartEngine.bind(this)('maia2', e);
+            restartEngine.bind(this)('maia2', e, loadEntry);
         };
     }
     

--- a/app/assets/js/instance/setupEnvironment.js
+++ b/app/assets/js/instance/setupEnvironment.js
@@ -159,11 +159,15 @@ export default async function setupEnvironment(startpos, dimensions) {
 
         chessboardComponentsElem.classList.add(chessFont);
         
-        new ResizeObserver(entries => {
+        // Kept on the instance so close() can disconnect it. Without a reference the
+        // observer stayed alive with an active observation and pinned the detached board.
+        this.boardResizeObserver = new ResizeObserver(entries => {
             const width = entries[0].target.getBoundingClientRect().width;
 
             chessgroundElem.style.height = `${GET_BOARD_HEIGHT_FROM_WIDTH(width, boardDimensions)}px`;
-        }).observe(chessgroundElem);
+        });
+
+        this.boardResizeObserver.observe(chessgroundElem);
 
         this.chessground = window.ChessgroundX(chessgroundElem, { 
             disableContextMenu: true,

--- a/app/assets/js/misc/translationProcessor.js
+++ b/app/assets/js/misc/translationProcessor.js
@@ -87,17 +87,28 @@
 			translateConfig();
 
 			if(firstLoad) {
-				const observer = new MutationObserver(m => {
-					if(mutationCounter<25) {
-						updateTextContent();
-					}
-	
-					document.querySelectorAll('.language-dropdown-input')
-						.forEach(initializeLanguageDropdown);
-	
-					mutationCounter++;
+				let retranslateTimeout = null;
+
+				// updateTextContent() writes innerText, which is itself a childList mutation,
+				// so this observer re-triggers itself. The counter alone still allowed 25 full
+				// document sweeps per second, and Chessground mutates the DOM on every board
+				// update. Coalesce the bursts into one pass instead.
+				const observer = new MutationObserver(() => {
+					if(retranslateTimeout !== null) return;
+
+					retranslateTimeout = setTimeout(() => {
+						retranslateTimeout = null;
+
+						if(mutationCounter < 25) {
+							updateTextContent();
+							mutationCounter++;
+						}
+
+						document.querySelectorAll('.language-dropdown-input')
+							.forEach(initializeLanguageDropdown);
+					}, 100);
 				});
-	
+
 				observer.observe(document, { childList: true, subtree: true });
 			}
 		} catch(error){
@@ -117,7 +128,9 @@
 
 	function translateConfig() {
 		Object.keys(configTranslations).map(async key => {
-			const parentElement = await WAIT_FOR_ELEMENT(`[data-key="${key}"]`);
+			// The default timeout is ~2.8 hours, so every key without a matching element
+			// left a 100ms poll running for the rest of the session
+			const parentElement = await WAIT_FOR_ELEMENT(`[data-key="${key}"]`, 10000);
 			const customInputElem = parentElement?.closest('.custom-input');
 
 			if(!customInputElem) return;

--- a/appServer/ui/js/console.js
+++ b/appServer/ui/js/console.js
@@ -1,4 +1,6 @@
-const MAX_LOG_LINES = 100000;
+// Each line is a div with two spans, so 100000 meant roughly 300k nodes per console,
+// per instance, fed by an engine emitting thousands of info lines a second
+const MAX_LOG_LINES = 2000;
 const CONSOLE_OBJS = new Map();
 
 async function log(text, type = 'info', identifierObj) {
@@ -26,7 +28,7 @@ async function log(text, type = 'info', identifierObj) {
     div.querySelector('.msg-body').textContent = text;
 
     const currentFilter = filterInput.value.toLowerCase();
-    if(currentFilter && !text.toLowerCase().includes(currentFilter))
+    if(currentFilter && !div.textContent.toLowerCase().includes(currentFilter))
         div.style.display = 'none';
 
     const shouldScroll = logDiv.scrollHeight - logDiv.clientHeight <= logDiv.scrollTop + 60;


### PR DESCRIPTION
Engine load pollers are cleared only on success. When a worker fails to load it was never pushed to this.engines, so killEngines() can’t reach it - the worker stays alive and the interval keeps posting to it at 10Hz for the life of the page. Pending loads are tracked and torn down now. alreadyRestarted was never set to true either, so its guard was dead.

Also: chessground.destroy() was never called, which leaks the document/window listeners it binds per instance; the board ResizeObserver was created without a reference so it could never be disconnected; the translation MutationObserver retriggers itself through innerText and allowed 25 full-document sweeps a second; WAIT_FOR_ELEMENT’s default timeout is ~2.8h and translateConfig calls it once per key; pipContextQueue only drained on bestmove; square hover listeners were never removed; MAX_LOG_LINES was 100000.