### PR TITLE
drop missing script tags, fix canonical, duplicate ads and link targets

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>Page Not Found / A.C.A.S</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -20,7 +20,6 @@
     <meta property="og:type" content="website">
     <script type="text/javascript"src="assets/js/tag-manager.js"></script>
     <script async="" type="text/javascript" src="https://www.googletagmanager.com/gtm.js?id=GTM-5499BQ4B"></script>
-    <script async="" type="text/javascript" src="index.js"></script>
     <script defer="" type="text/javascript" src="assets/libraries/klaro/config.js"></script>
     <script defer="" type="text/javascript" src="assets/libraries/klaro/klaro.js"></script>
     <script async="" src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7248123202489335" crossorigin="anonymous"></script>
@@ -31,3 +30,4 @@
         <a href="/A.C.A.S/">← Go back home</a>
     </div>
 </body>
+</html>

--- a/app/dev/index.html
+++ b/app/dev/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>Testing Facility / A.C.A.S</title>
     <meta charset="UTF-8">

--- a/app/index.html
+++ b/app/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 	<head>
 		<title>A.C.A.S</title>
 		<link rel="stylesheet" type="text/css" href="gui.css"/>
@@ -59,7 +59,7 @@
 				<div id="tos-title">Welcome, my friend!</div>
 				<div class="tos-description">We're thrilled to have you here! A.C.A.S is all set and ready to provide you with a fantastic experience. Its circuits are already powered up and functioning, thanks to the userscript that has been installed.<br><br>You're fully equipped to explore and enjoy all the features and benefits that A.C.A.S brings to the table. Whether it's assistance, engagement, or a touch of fun you're seeking, A.C.A.S is here to serve you.</div>
 				<div class="language-dropdown-input"><div class="dropdown-input-container">
-					<img class="selected-language-img" src="../assets/images/flags/us.svg">
+					<img class="selected-language-img" src="../assets/images/flags/us.svg" alt="">
 					<div class="dropdown-list-container">
 					</div>
 				</div></div>
@@ -67,7 +67,7 @@
 				<div class="tos-checkbox-container">
 					<label class="tos-checkbox-label">
 						<input type="checkbox" id="tos-checkbox"/>
-						<span><a href="../tos" class="tos-link" target="_about">I have read and agree to the Terms of Service.</a></span>
+						<span><a href="../tos" class="tos-link" target="_blank" rel="noopener noreferrer">I have read and agree to the Terms of Service.</a></span>
 					</label>
 				</div>
 				<button id="tos-continue-button" class="acas-fancy-button" disabled>Kickstart A.C.A.S</button>
@@ -81,30 +81,30 @@
 			<div id="install-buttons">
 				<div class="small-buttons">
 					<div class="language-dropdown-input"><div class="dropdown-input-container">
-						<img class="selected-language-img" src="../assets/images/flags/us.svg">
+						<img class="selected-language-img" src="../assets/images/flags/us.svg" alt="">
 						<div class="dropdown-list-container">
 						</div>
 					</div></div>
 					<a class="install-open-home-btn" href="../install" title="Open Documentation">( ╹ -╹)?</a>
 				</div>
 				<div id="install-buttons-inner-container">
-					<a href="https://www.tampermonkey.net/" class="install-notification-btn tampermonkey-btn" target="_about">Tampermonkey</a>
-					<a href="https://greasyfork.org/en/scripts/459137" class="install-notification-btn install-userscript-btn" target="_about">Install Userscript</a>
+					<a href="https://www.tampermonkey.net/" class="install-notification-btn tampermonkey-btn" target="_blank" rel="noopener noreferrer">Tampermonkey</a>
+					<a href="https://greasyfork.org/en/scripts/459137" class="install-notification-btn install-userscript-btn" target="_blank" rel="noopener noreferrer">Install Userscript</a>
 				</div>
 			</div>
 			<div id="install-mobile-container">
 				<div class="install-subtitle">Mobile users can try these ♡ ⤵</div>
 				<div id="install-buttons-mobile">
-					<a href="https://play.google.com/store/apps/details?id=com.lemurbrowser.exts" class="install-notification-btn install-lemur-btn" target="_about">(Android) Lemur</a>
-					<a href="../install/" class="install-notification-btn install-ios-btn" target="_about">(iOS) 😔</a>
+					<a href="https://play.google.com/store/apps/details?id=com.lemurbrowser.exts" class="install-notification-btn install-lemur-btn" target="_blank" rel="noopener noreferrer">(Android) Lemur</a>
+					<a href="../install/" class="install-notification-btn install-ios-btn" target="_blank" rel="noopener noreferrer">(iOS) 😔</a>
 				</div>
 			</div>
 		</div>
 
 		<!-- ACAS HEADER CONTAINER-->
 		<div id="acas-header">
-			<a id="acas-logo" href="../" target="_blank">
-				<img id="acas-logo-img" src="../assets/images/logo.png">
+			<a id="acas-logo" href="../" target="_blank" rel="noopener noreferrer">
+				<img id="acas-logo-img" src="../assets/images/logo.png" alt="">
 				<div id="acas-logo-text-container">
 					<div id="acas-logo-main">A.C.A.S<div id="acas-version-tag">V2</div></div>
 					<div id="acas-logo-secondary">Chess Assistance</div>
@@ -115,17 +115,17 @@
 				<span>(´｡• ◡ •｡`) ♡ <span id="acas-is-free-reminder-text">Help by giving feedback!</span> ⤵</span>
 				<div class="acas-social-actions">
 					<div class="language-dropdown-input"><div class="dropdown-input-container">
-						<img class="selected-language-img" src="../assets/images/flags/us.svg">
+						<img class="selected-language-img" src="../assets/images/flags/us.svg" alt="">
 						<div class="dropdown-list-container">
 						</div>
 					</div></div>
-					<a class="header-social-button greasyfork-button acas-fancy-button" href="https://greasyfork.org/en/scripts/459137/feedback" target="_blank" title="Give A.C.A.S positive feedback on Greasyfork">
+					<a class="header-social-button greasyfork-button acas-fancy-button" href="https://greasyfork.org/en/scripts/459137/feedback" target="_blank" title="Give A.C.A.S positive feedback on Greasyfork" rel="noopener noreferrer">
 						<i class="bi bi-chat-text"></i>
 					</a>
-                    <a class="header-social-button affiliate-button acas-fancy-button" href="../contributing" target="_blank" title="Support A.C.A.S development">
+                    <a class="header-social-button affiliate-button acas-fancy-button" href="../contributing" target="_blank" title="Support A.C.A.S development" rel="noopener noreferrer">
 						<i class="bi bi-heart-fill"></i>
 					</a>
-					<a class="header-social-button github-button acas-fancy-button" href="https://github.com/Psyyke/A.C.A.S" target="_blank" title="Star A.C.A.S on GitHub">
+					<a class="header-social-button github-button acas-fancy-button" href="https://github.com/Psyyke/A.C.A.S" target="_blank" title="Star A.C.A.S on GitHub" rel="noopener noreferrer">
 						<i class="bi bi-github"></i>
 					</a>
 				</div>
@@ -152,11 +152,11 @@
 							<div class="sites-subtitle">(Should work flawlessly)</div>
 						</div>
 						<div class="sites-list">
-							<a class="chess-site-link popular-chess-site-link acas-fancy-button" href="https://www.chess.com/play" target="_blank">Chess.com</a>
-							<a class="chess-site-link popular-chess-site-link acas-fancy-button" href="https://www.lichess.org" target="_blank">Lichess.org</a>
-							<a class="chess-site-link acas-fancy-button" href="https://playstrategy.org" target="_blank">Playstrategy.org</a>
-							<a class="chess-site-link acas-fancy-button" href="https://www.pychess.org/" target="_blank">Pychess.org</a>
-							<a class="chess-site-link acas-fancy-button" href="http://chess.net/" target="_blank">Chess.net</a>
+							<a class="chess-site-link popular-chess-site-link acas-fancy-button" href="https://www.chess.com/play" target="_blank" rel="noopener noreferrer">Chess.com</a>
+							<a class="chess-site-link popular-chess-site-link acas-fancy-button" href="https://www.lichess.org" target="_blank" rel="noopener noreferrer">Lichess.org</a>
+							<a class="chess-site-link acas-fancy-button" href="https://playstrategy.org" target="_blank" rel="noopener noreferrer">Playstrategy.org</a>
+							<a class="chess-site-link acas-fancy-button" href="https://www.pychess.org/" target="_blank" rel="noopener noreferrer">Pychess.org</a>
+							<a class="chess-site-link acas-fancy-button" href="http://chess.net/" target="_blank" rel="noopener noreferrer">Chess.net</a>
 						</div>
 					</div>
 					<div class="stable-sites">
@@ -165,10 +165,10 @@
 							<div class="sites-subtitle">(Works fine, but might have some minor bugs)</div>
 						</div>
 						<div class="sites-list">
-							<a class="chess-site-link acas-fancy-button" href="https://app.edchess.io/" target="_blank">EdChess.io</a>
-							<a class="chess-site-link acas-fancy-button" href="https://chess.org" target="_blank">Chess.org</a>
-							<a class="chess-site-link acas-fancy-button" href="https://papergames.io/en/chess" target="_blank">Papergames.io</a>
-							<a class="chess-site-link acas-fancy-button" href="https://www.coolmathgames.com/0-chess" target="_blank">Coolmathgames.com</a>
+							<a class="chess-site-link acas-fancy-button" href="https://app.edchess.io/" target="_blank" rel="noopener noreferrer">EdChess.io</a>
+							<a class="chess-site-link acas-fancy-button" href="https://chess.org" target="_blank" rel="noopener noreferrer">Chess.org</a>
+							<a class="chess-site-link acas-fancy-button" href="https://papergames.io/en/chess" target="_blank" rel="noopener noreferrer">Papergames.io</a>
+							<a class="chess-site-link acas-fancy-button" href="https://www.coolmathgames.com/0-chess" target="_blank" rel="noopener noreferrer">Coolmathgames.com</a>
 						</div>
 					</div>
 					<div class="unstable-sites">
@@ -177,12 +177,12 @@
 							<div class="sites-subtitle">(Might work fine, be buggy or not work at all)</div>
 						</div>
 						<div class="sites-list">
-							<a class="chess-site-link acas-fancy-button" href="https://chessarena.com/lobby" target="_blank">Chessarena.com</a>
-							<a class="chess-site-link acas-fancy-button" href="https://gameknot.com" target="_blank">Gameknot.com</a>
-							<a class="chess-site-link acas-fancy-button" href="https://immortal.game/" target="_blank">Immortal.game</a>
-							<a class="chess-site-link acas-fancy-button" href="https://www.freechess.club/" target="_blank">Freechess.club</a>
-							<a class="chess-site-link acas-fancy-button" href="https://www.chessclub.com" target="_blank">Chessclub.com</a>
-							<a class="chess-site-link acas-fancy-button" href="dev" target="_blank">(Developer Page)</a>
+							<a class="chess-site-link acas-fancy-button" href="https://chessarena.com/lobby" target="_blank" rel="noopener noreferrer">Chessarena.com</a>
+							<a class="chess-site-link acas-fancy-button" href="https://gameknot.com" target="_blank" rel="noopener noreferrer">Gameknot.com</a>
+							<a class="chess-site-link acas-fancy-button" href="https://immortal.game/" target="_blank" rel="noopener noreferrer">Immortal.game</a>
+							<a class="chess-site-link acas-fancy-button" href="https://www.freechess.club/" target="_blank" rel="noopener noreferrer">Freechess.club</a>
+							<a class="chess-site-link acas-fancy-button" href="https://www.chessclub.com" target="_blank" rel="noopener noreferrer">Chessclub.com</a>
+							<a class="chess-site-link acas-fancy-button" href="dev" target="_blank" rel="noopener noreferrer">(Developer Page)</a>
 						</div>
 					</div>
 				</div>
@@ -238,7 +238,7 @@
 					<div class="control-panel-btn no-select acas-fancy-button"
 						onclick="if (!location.href.includes('hidden=true')) location.href += (location.href.includes('?') ? '&' : '?') + 'hidden=true';"
 						title="Show Hidden Settings">👀</div>
-					<a target="_about" href="../usage/" class="control-panel-btn no-select acas-fancy-button" title="Open Documentation">📖</a>
+					<a target="_blank" href="../usage/" class="control-panel-btn no-select acas-fancy-button" title="Open Documentation" rel="noopener noreferrer">📖</a>
 					<div id="import-settings-btn" class="control-panel-btn no-select acas-fancy-button" title="Import Settings">📂</div>
 					<div id="export-settings-btn" class="control-panel-btn no-select acas-fancy-button" title="Export Settings">💾</div>
 					<div id="reset-settings-btn" class="control-panel-btn no-select acas-fancy-button" title="Reset Settings">🗑️</div>
@@ -263,7 +263,7 @@
 								<input type="checkbox" data-key="engineEnabled" data-default-value="true"><div class="checkbox-fill">✔</div></div>
 							</div>
 							<div class="custom-input"><div><div class="input-title">Chess Engine</div>
-								<a href="../usage/" target="_blank"><div class="input-subtitle">Read more here</div></a></div>
+								<a href="../usage/" target="_blank" rel="noopener noreferrer"><div class="input-subtitle">Read more here</div></a></div>
 
 								<div class="floaty-wrapper">
 									<button class="open-floaty-btn acas-fancy-button">⚙️</button>
@@ -342,13 +342,13 @@
 														<div class="dropdown-input-container">
 															<input disabled type="text" additional-type="dropdown" data-key="externalChessEngine" data-default-value="" placeholder="None"><div class="dropdown-icon"></div>
 															<div class="dropdown-list-container hidden" style="height: fit-content; max-height: 300px;"></div>
-															<p id="install-acas-server-text"><a href="/A.C.A.S/usage/#external" target="_blank"><span data-translation-external-engine-2>Install the A.C.A.S server</span></a> <span data-translation-external-engine-3>to use external engines</span></p>
+															<p id="install-acas-server-text"><a href="/A.C.A.S/usage/#external" target="_blank" rel="noopener noreferrer"><span data-translation-external-engine-2>Install the A.C.A.S server</span></a> <span data-translation-external-engine-3>to use external engines</span></p>
 														</div>
 													</div>
 													<p data-translation-experimental-warning>This feature is experimental, it might not work well!</p>
 												</div>
 
-												<a target="_blank" href="../usage/" data-translation-learn-more-here>Learn more about these features here.</a>
+												<a target="_blank" href="../usage/" data-translation-learn-more-here rel="noopener noreferrer">Learn more about these features here.</a>
 											</section>
 										</div>
 									</dialog>
@@ -391,7 +391,7 @@
 													</div>
 												</div>
 
-												<a target="_blank" href="../usage/" data-translation-learn-more-here>Learn more about these features here.</a>
+												<a target="_blank" href="../usage/" data-translation-learn-more-here rel="noopener noreferrer">Learn more about these features here.</a>
 											</section>
 										</div>
 									</dialog>
@@ -403,7 +403,7 @@
 								<input type="textfield" data-key="engineEnemyElo" data-default-value="1500" data-between="600-2600">
 							</div>
 							<div id="lc0-weight-dropdown" class="hidden dropdown-input custom-input"><div><div class="input-title">Lc0 Weights</div>
-								<a href="../usage/" target="_blank"><div class="input-subtitle">Read more here</div></a></div><div class="dropdown-input-container">
+								<a href="../usage/" target="_blank" rel="noopener noreferrer"><div class="input-subtitle">Read more here</div></a></div><div class="dropdown-input-container">
 								<input type="text" additional-type="dropdown" data-key="lc0Weight" data-default-value="maia-1100.pb" placeholder="1100 elo"><div class="dropdown-icon"></div>
 								<div class="dropdown-list-container">
 									<div class="dropdown-item" data-value="maia-1100.pb">1100 elo (Maia) 1.7MB</div>
@@ -430,7 +430,7 @@
 								<input type="textfield" data-key="engineNodes" data-default-value="1" data-between="1-99999999">
 							</div>
 							<div id="chess-variant-dropdown" class="dropdown-input custom-input hidden"><div><div class="input-title">Chess Variant</div>
-								<a href="../usage/" target="_blank"><div class="input-subtitle">Read more here</div></a></div><div class="dropdown-input-container">
+								<a href="../usage/" target="_blank" rel="noopener noreferrer"><div class="input-subtitle">Read more here</div></a></div><div class="dropdown-input-container">
 								<input disabled type="text" additional-type="dropdown" data-key="chessVariant" data-default-value="Chess" placeholder="Chess"><div class="dropdown-icon"></div>
 								<div class="dropdown-list-container"></div>
 							</div></div>
@@ -506,7 +506,7 @@
 													</div>
 												</div>
 
-												<a target="_blank" href="../usage/" data-translation-learn-more-here>Learn more about these features here.</a>
+												<a target="_blank" href="../usage/" data-translation-learn-more-here rel="noopener noreferrer">Learn more about these features here.</a>
 											</section>
 										</div>
 									</dialog>
@@ -553,7 +553,7 @@
 
 												<p data-translation-experimental-warning>This feature is experimental, it might not work well!</p>
 
-												<a target="_blank" href="../usage/" data-translation-learn-more-here>Learn more about these features here.</a>
+												<a target="_blank" href="../usage/" data-translation-learn-more-here rel="noopener noreferrer">Learn more about these features here.</a>
 											</section>
 										</div>
 									</dialog>
@@ -599,7 +599,7 @@
 													</div>
 												</div>
 
-												<a target="_blank" href="../usage/" data-translation-learn-more-here>Learn more about these features here.</a>
+												<a target="_blank" href="../usage/" data-translation-learn-more-here rel="noopener noreferrer">Learn more about these features here.</a>
 											</section>
 										</div>
 									</dialog>
@@ -662,7 +662,7 @@
 						</div>
 						<div id="hidden-setting-panel" class="setting-panel hidden">
 							<div class="setting-panel-title"><span class="hidden-panel-title">Hidden</span> 👻</div>
-							<div class="tos-reminder-setting-panel-item"><a href="../tos" class="tos-reminder-link" target="_blank">Remember to follow the ToS</a> 💖<br><small class="no-updates-disclaimer-text">Do not ask for updates for these</small><span> ↴</span></div>
+							<div class="tos-reminder-setting-panel-item"><a href="../tos" class="tos-reminder-link" target="_blank" rel="noopener noreferrer">Remember to follow the ToS</a> 💖<br><small class="no-updates-disclaimer-text">Do not ask for updates for these</small><span> ↴</span></div>
 							<div class="input-combination-box">
 								<div class="checkbox-input custom-input"><div><div class="input-title">Auto Move</div>
 									<div class="input-subtitle">For Chess.com. Use only against bots</div></div><div class="checkbox-container">
@@ -735,7 +735,7 @@
 											</div>
 										</div>
 
-										<a target="_blank" href="../usage/" data-translation-learn-more-here>Learn more about these features here.</a>
+										<a target="_blank" href="../usage/" data-translation-learn-more-here rel="noopener noreferrer">Learn more about these features here.</a>
 									</section>
 								</div>
 							</dialog>
@@ -799,12 +799,12 @@
 		
 		<div id="footer">
 			<div id="footer-links">
-				<a class="footer-link" href="https://github.com/Psyyke/A.C.A.S" target="_about">GitHub</a>
-				<a class="footer-link" href="https://greasyfork.org/en/scripts/459137-a-c-a-s-advanced-chess-assistance-system" target="_about">GreasyFork</a>
-				<a class="footer-link" href="https://github.com/Hakorr" target="_about">Author</a>
-				<a class="footer-link" href="../tos" target="_about">ToS</a>
-				<a class="footer-link" href="../privacy" target="_about">Privacy</a>
-				<a class="footer-link" href="../#/" target="_about">Documentation</a>
+				<a class="footer-link" href="https://github.com/Psyyke/A.C.A.S" target="_blank" rel="noopener noreferrer">GitHub</a>
+				<a class="footer-link" href="https://greasyfork.org/en/scripts/459137-a-c-a-s-advanced-chess-assistance-system" target="_blank" rel="noopener noreferrer">GreasyFork</a>
+				<a class="footer-link" href="https://github.com/Hakorr" target="_blank" rel="noopener noreferrer">Author</a>
+				<a class="footer-link" href="../tos" target="_blank" rel="noopener noreferrer">ToS</a>
+				<a class="footer-link" href="../privacy" target="_blank" rel="noopener noreferrer">Privacy</a>
+				<a class="footer-link" href="../#/" target="_blank" rel="noopener noreferrer">Documentation</a>
 			</div>
 			<div id="thanks-for-using-footer-text" class="footer-small-text">Thanks for using A.C.A.S, a handcrafted project made by a solo developer.</div>
 		</div>

--- a/appServer/ui/index.html
+++ b/appServer/ui/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws://localhost:*; img-src 'self' data: blob:;">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -17,8 +17,8 @@
 
 <body>
 <div id="acas-header">
-    <a id="acas-logo" class="external" href="https://psyyke.github.io/A.C.A.S/" target="_blank">
-        <img id="acas-logo-img" src="./images/logo.png">
+    <a id="acas-logo" class="external" href="https://psyyke.github.io/A.C.A.S/" target="_blank" rel="noopener noreferrer">
+        <img id="acas-logo-img" src="./images/logo.png" alt="">
         <div id="acas-logo-text-container">
             <div id="acas-logo-main">A.C.A.S<div id="acas-version-tag">V2</div></div>
             <div id="acas-logo-secondary">Calculation Server</div>
@@ -27,10 +27,10 @@
     <div id="acas-is-free-reminder">
         <span>(´｡• ◡ •｡`) Psst! ♡ ⤵</span>
         <div class="acas-social-actions">
-            <a class="header-social-button github-button acas-fancy-button external" href="https://github.com/Psyyke/A.C.A.S" target="_blank" title="Star A.C.A.S on GitHub">
+            <a class="header-social-button github-button acas-fancy-button external" href="https://github.com/Psyyke/A.C.A.S" target="_blank" title="Star A.C.A.S on GitHub" rel="noopener noreferrer">
                 <i class="bi bi-github"></i>
             </a>
-            <a class="header-social-button affiliate-button acas-fancy-button external" href="https://psyyke.github.io/A.C.A.S/contributing/" target="_blank" title="Support A.C.A.S development">
+            <a class="header-social-button affiliate-button acas-fancy-button external" href="https://psyyke.github.io/A.C.A.S/contributing/" target="_blank" title="Support A.C.A.S development" rel="noopener noreferrer">
                 <i class="bi bi-heart-fill"></i>
             </a>
         </div>

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>Blog / A.C.A.S</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -23,7 +23,6 @@
     <meta property="og:type" content="website">
     <script type="text/javascript"src="../assets/js/tag-manager.js"></script>
     <script async="" type="text/javascript" src="https://www.googletagmanager.com/gtm.js?id=GTM-5499BQ4B"></script>
-    <script async="" type="text/javascript" src="../index.js"></script>
     <script defer="" type="text/javascript" src="../assets/libraries/klaro/config.js"></script>
     <script defer="" type="text/javascript" src="../assets/libraries/klaro/klaro.js"></script>
     <script defer="" type="text/javascript" src="../assets/libraries/highlight/highlight.min.js"></script>
@@ -62,15 +61,15 @@
                 <a href="../faq/" aria-label="Frequently Asked Questions" class="fancy-btn"><i class="bi bi-chat-square-quote"></i>FAQ</a>
                 <a href="../blog/" aria-label="View A.C.A.S blog" class="fancy-btn"><i class="bi bi-pen"></i>Blog</a>
                 <a href="../contributing/" aria-label="Contribute to A.C.A.S" class="fancy-btn"><i class="bi bi-heart"></i></a>
-                <a href="https://github.com/psyyke/A.C.A.S" target="_blank" class="github-corner fancy-btn" aria-label="View source on Github"><i class="bi bi-github"></i></a>
+                <a href="https://github.com/psyyke/A.C.A.S" target="_blank" class="github-corner fancy-btn" aria-label="View source on Github" rel="noopener noreferrer"><i class="bi bi-github"></i></a>
             </div>
         </header>
         <div class="content">
-            <img style="right: -40px;width: 120px;top: -40px;transform: rotate(5deg);" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/wN.svg">
-            <img style="left: -60px;width: 140px;top: 130px;transform: rotate(-6deg);" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/bK.svg">
-            <img style="left: -155px;width: 150px;top: 0;filter: blur(3px);transform: rotate(26deg);opacity: 0.7;" class="floaty-piece floaty-mobile-fix floaty-subpage" src="../assets/images/pieces/staunty/wQ.svg">
-            <img style="right: -130px;width: 120px;top: 75px;filter: blur(4px);transform: rotate(-26deg);opacity: 0.65;" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/bK.svg">
-            <img style="right: -40px;width: 90px;top: 220px;transform: rotate(15deg);" class="floaty-piece floaty-subpage" src="../assets/images/pieces/staunty/bR.svg">
+            <img style="right: -40px;width: 120px;top: -40px;transform: rotate(5deg);" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/wN.svg" alt="">
+            <img style="left: -60px;width: 140px;top: 130px;transform: rotate(-6deg);" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/bK.svg" alt="">
+            <img style="left: -155px;width: 150px;top: 0;filter: blur(3px);transform: rotate(26deg);opacity: 0.7;" class="floaty-piece floaty-mobile-fix floaty-subpage" src="../assets/images/pieces/staunty/wQ.svg" alt="">
+            <img style="right: -130px;width: 120px;top: 75px;filter: blur(4px);transform: rotate(-26deg);opacity: 0.65;" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/bK.svg" alt="">
+            <img style="right: -40px;width: 90px;top: 220px;transform: rotate(15deg);" class="floaty-piece floaty-subpage" src="../assets/images/pieces/staunty/bR.svg" alt="">
             <!-- PAGE CONTENT -->
             <article class="markdown-section-sub markdown-section" id="main">
                 <section>
@@ -79,25 +78,25 @@
                 <section>
                     <h2 id="basics">History of A.C.A.S</h2>
 
-                    <p>I (<a href="https://github.com/Hakorr">Haka</a>) gave birth to <a href="https://greasyfork.org/en/scripts/459137-1-chess-assistant-a-c-a-s-advanced-chess-assistance-system?version=1143684" target="_blank">A.C.A.S v1.0</a> on Jan 30, 2023. It was the first of its kind userscript on GreasyFork. There had always been extensions and external programs that did the same thing, but nothing was as easy to use as A.C.A.S. The goal was to be very easy to use with clean UI. Here's a screenshot of the v1.0,</p>
+                    <p>I (<a href="https://github.com/Hakorr">Haka</a>) gave birth to <a href="https://greasyfork.org/en/scripts/459137-1-chess-assistant-a-c-a-s-advanced-chess-assistance-system?version=1143684" target="_blank" rel="noopener noreferrer">A.C.A.S v1.0</a> on Jan 30, 2023. It was the first of its kind userscript on GreasyFork. There had always been extensions and external programs that did the same thing, but nothing was as easy to use as A.C.A.S. The goal was to be very easy to use with clean UI. Here's a screenshot of the v1.0,</p>
                     <img src="../assets/images/oldacas.png" height="300" alt="A.C.A.S v1.0"></img>
                     <p>I had already developed userscripts for two years at that point, but hadn't played chess; literally <b>zero</b>, nada, experience. How do chess engines work? What's UCI or a FEN? Most importantly, how does one even play chess in the first place? Had to learn a lot and there were times when people asked for features I didn't even know were a thing in chess. "<i>En passant? Sorry, I don't speak that language.</i>"</p>
                     
-                    <p>The first version of A.C.A.S took a lot of Googling even though it was made in a weekend. It felt like there wasn't much easy to understand information about communicating with chess engines, so the engine was a black box to me. Credit where it's due, I relied heavily on <a href="https://op12no2.github.io/lozza-ui/" target="_blank">Lozza.js</a>, because it had a web GUI with the engine already running. It was written in JS, so I could see how it works behind the scenes. I learned a lot from it, and imitated a lot of what it was doing at the start. I'm lucky to have open source projects from smart people to learn from!
+                    <p>The first version of A.C.A.S took a lot of Googling even though it was made in a weekend. It felt like there wasn't much easy to understand information about communicating with chess engines, so the engine was a black box to me. Credit where it's due, I relied heavily on <a href="https://op12no2.github.io/lozza-ui/" target="_blank" rel="noopener noreferrer">Lozza.js</a>, because it had a web GUI with the engine already running. It was written in JS, so I could see how it works behind the scenes. I learned a lot from it, and imitated a lot of what it was doing at the start. I'm lucky to have open source projects from smart people to learn from!
                     
-                    <p>Once I got Lozza running on the userscript, I used a previous project I made called <a href="https://github.com/AugmentedWeb/UserGUI" target="_blank">UserGUI</a> as the GUI library.
+                    <p>Once I got Lozza running on the userscript, I used a previous project I made called <a href="https://github.com/AugmentedWeb/UserGUI" target="_blank" rel="noopener noreferrer">UserGUI</a> as the GUI library.
                     A.C.A.S v1 had basic settings for setting the engine ELO, and for enabling external move highlighting. It didn't have the move arrows yet since highlighting the square was easier to implement. Also, only chess.com was supported. The project gained installs organically without me having to advertise anything, and quickly gained more installs that I had ever gotten on any of my userscripts.</p>
                     
                     <p>Everything was working fine, but it didn't take long to realize that JS based chess engines aren't that fast to calculate deep depths. Problem was that many of the powerful engines at the time were blocked by chess.com's CORS policies.
                     I had to find a way to calculate the moves externally. I never considered fetching the moves from a server an option since it would cost a lot, not be privacy friendly or it might've had a large latency. I considered making A.C.A.S into a browser extension, but installing an extension manually is much more difficult than just installing a userscript, so I decided not to go that route. And I just like userscripts more.</p>
                     
                     <p>I figured the only way to bypass the CORS policies was to run the engine on a completely different tab, on a different domain.
-                    As far as I knew, that kind of cross-tab communication had never been implemented on userscripts before, so I took it as a challenge and wrote my own library for it called <a href="https://github.com/AugmentedWeb/CommLink" target="_blank">CommLink</a>, which uses the userscript storage as a middle-man between the two tabs.
+                    As far as I knew, that kind of cross-tab communication had never been implemented on userscripts before, so I took it as a challenge and wrote my own library for it called <a href="https://github.com/AugmentedWeb/CommLink" target="_blank" rel="noopener noreferrer">CommLink</a>, which uses the userscript storage as a middle-man between the two tabs.
                     Once I had made sure it was stable enough, I made a ton of changes to the userscript, and created an entirely new GUI. See a picture of the first v2 GUI below,</p>
                 
                     <img src="../assets/images/oldgui.png" alt="A.C.A.S v2.0 GUI"></img>
 
-                    <p>A.C.A.S v2 focused on making A.C.A.S functional for any site or any chess variant so that it's future proof. With the update, I also added more features, such as move arrows via another library I created at the time, called <a href="https://github.com/Hakorr/UniversalBoardDrawer" target="_blank">UniversalBoardDrawer</a>. The time between the first release of A.C.A.S, and A.C.A.S v2 was 5 months. Most of the work was done during a summer break, at least 8 hours a day, for a couple weeks during the first weeks of summer.</p>
+                    <p>A.C.A.S v2 focused on making A.C.A.S functional for any site or any chess variant so that it's future proof. With the update, I also added more features, such as move arrows via another library I created at the time, called <a href="https://github.com/Hakorr/UniversalBoardDrawer" target="_blank" rel="noopener noreferrer">UniversalBoardDrawer</a>. The time between the first release of A.C.A.S, and A.C.A.S v2 was 5 months. Most of the work was done during a summer break, at least 8 hours a day, for a couple weeks during the first weeks of summer.</p>
                     
                     <p>A lot has changed since then. As of writing this blog, A.C.A.S v2 came out 975 days ago, that's a lot. I've had times when I've worked hard on the project, and times when I didn't touch it for at least 6 months. Nowadays it's so much more stable with the addition of the floating panel. It has more features, but also some features are broken for a long time due to me not being the best programmer, combined with having to prioritize other things. I'm fine with not having perfect code as this is my first project of this scale, and I don't aspire to be a perfect programmer.</p>
 
@@ -119,11 +118,11 @@
                     </p>
 
                     <p class="tip">
-                    The <a target="_about" href="../app?shl=displayMovesOnExternalSite">Moves On
+                    The <a target="_blank" href="../app?shl=displayMovesOnExternalSite" rel="noopener noreferrer">Moves On
                     External Site</a> setting is one of the only features that actually inserts something
                     into the page. While it doesn't yell <b>"A.C.A.S CREATED ME!"</b> (<i>since it's minimal and fairly neutral</i>), it does
                     modify the document, which means a site could detect it if it actively
-                    looked for such changes. Enabling <a target="_about" href="../app?shl=isUserscriptGhost">Ghost Mode</a> attempts to disable all detectable external features.
+                    looked for such changes. Enabling <a target="_blank" href="../app?shl=isUserscriptGhost" rel="noopener noreferrer">Ghost Mode</a> attempts to disable all detectable external features.
                     </p>
 
                     <h3 id="reading-the-board">Reading the board</h3>
@@ -329,11 +328,10 @@ addSupportedChessSite('lichess.org', {
             <!-- PAGE CONTENT ENDS -->
         </div>
         <footer>
-            <img style="right: -70px;bottom: -35px;width: 200px;" class="floaty-piece floaty-footer" src="../assets/images/pieces/staunty/wQ.svg"/>
+            <img style="right: -70px;bottom: -35px;width: 200px;" class="floaty-piece floaty-footer" src="../assets/images/pieces/staunty/wQ.svg" alt=""/>
             <section><a href="../tos">Terms of Service</a><a href="../privacy">Privacy Policy</a><a href="https://www.gnu.org/licenses/gpl-3.0.en.html">Licensed with GPLv3</a><a href="https://github.com/Hakorr">Contact Me</a></section>
         </footer>
     </main>
     <script async="" src="../assets/js/site-additional-content.js"></script>
-    <script async="" src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7248123202489335" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/board/index.html
+++ b/board/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 	<head>
 		<title>Board / A.C.A.S</title>
         <link rel="stylesheet" type="text/css" href="board.css"/>
@@ -10,10 +10,9 @@
 		<meta property="og:description" content="Full‑screen chess board viewer with FEN and orientation params. Supports animated sequences.">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<script src="../app/assets/js/globals.js"></script>
-		<script src="../assets/js/acas-i18n-processor.js"></script>
 		<script src="../assets/libraries/FileSaver/FileSaver.js"></script>
 		<script src="../assets/libraries/UniversalBoardDrawer/UniversalBoardDrawer.js"></script>
-        <script type="module" src="../assets/js/acas-load-modules.js"></script>
+		<script type="module" src="../app/assets/js/misc/exposeModules.js"></script>
 		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css"/>
 		<link rel="stylesheet" type="text/css" href="../assets/css/chessground.base.css"/>
 		<link rel="stylesheet" type="text/css" href="../assets/css/chessground.brown.css"/>
@@ -28,7 +27,7 @@
 		<link rel="icon" type="image/x-icon" href="../favicon.ico"/>
 </head>
 <body class="staunty">
-    <a href="../" target="_blank" class="back-to-acas-link" rel="noopener">Back to A.C.A.S</a>
+    <a href="../" class="back-to-acas-link">Back to A.C.A.S</a>
     <div id="board"></div>
     <script>
 		(function initWhenReady() {
@@ -88,3 +87,4 @@
 		})();
     </script>
 </body>
+</html>

--- a/contributing/index.html
+++ b/contributing/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>Contributing / A.C.A.S</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -22,7 +22,6 @@
     <meta property="og:type" content="website">
     <script type="text/javascript"src="../assets/js/tag-manager.js"></script>
     <script async="" type="text/javascript" src="https://www.googletagmanager.com/gtm.js?id=GTM-5499BQ4B"></script>
-    <script async="" type="text/javascript" src="../index.js"></script>
     <script defer="" type="text/javascript" src="../assets/libraries/klaro/config.js"></script>
     <script defer="" type="text/javascript" src="../assets/libraries/klaro/klaro.js"></script>
     <script async="" src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7248123202489335" crossorigin="anonymous"></script>
@@ -39,15 +38,15 @@
                 <a href="../faq/" aria-label="Frequently Asked Questions" class="fancy-btn"><i class="bi bi-chat-square-quote"></i>FAQ</a>
                 <a href="../blog/" aria-label="View A.C.A.S blog" class="fancy-btn"><i class="bi bi-pen"></i>Blog</a>
                 <a href="../contributing/" aria-label="Contribute to A.C.A.S" class="fancy-btn"><i class="bi bi-heart"></i></a>
-                <a href="https://github.com/psyyke/A.C.A.S" target="_blank" class="github-corner fancy-btn" aria-label="View source on Github"><i class="bi bi-github"></i></a>
+                <a href="https://github.com/psyyke/A.C.A.S" target="_blank" class="github-corner fancy-btn" aria-label="View source on Github" rel="noopener noreferrer"><i class="bi bi-github"></i></a>
             </div>
         </header>
         <div class="content">
-            <img style="right: -40px;width: 120px;top: -40px;transform: rotate(5deg);" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/wN.svg">
-            <img style="left: -60px;width: 140px;top: 130px;transform: rotate(-6deg);" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/bK.svg">
-            <img style="left: -155px;width: 150px;top: 0;filter: blur(3px);transform: rotate(26deg);opacity: 0.7;" class="floaty-piece floaty-mobile-fix floaty-subpage" src="../assets/images/pieces/staunty/wQ.svg">
-            <img style="right: -130px;width: 120px;top: 75px;filter: blur(4px);transform: rotate(-26deg);opacity: 0.65;" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/bK.svg">
-            <img style="right: -40px;width: 90px;top: 220px;transform: rotate(15deg);" class="floaty-piece floaty-subpage" src="../assets/images/pieces/staunty/bR.svg">
+            <img style="right: -40px;width: 120px;top: -40px;transform: rotate(5deg);" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/wN.svg" alt="">
+            <img style="left: -60px;width: 140px;top: 130px;transform: rotate(-6deg);" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/bK.svg" alt="">
+            <img style="left: -155px;width: 150px;top: 0;filter: blur(3px);transform: rotate(26deg);opacity: 0.7;" class="floaty-piece floaty-mobile-fix floaty-subpage" src="../assets/images/pieces/staunty/wQ.svg" alt="">
+            <img style="right: -130px;width: 120px;top: 75px;filter: blur(4px);transform: rotate(-26deg);opacity: 0.65;" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/bK.svg" alt="">
+            <img style="right: -40px;width: 90px;top: 220px;transform: rotate(15deg);" class="floaty-piece floaty-subpage" src="../assets/images/pieces/staunty/bR.svg" alt="">
             <!-- PAGE CONTENT -->
             <article class="markdown-section-sub markdown-section" id="main">
                 <section>
@@ -107,11 +106,10 @@
             <!-- PAGE CONTENT ENDS -->
         </div>
         <footer>
-            <img style="right: -70px;bottom: -35px;width: 200px;" class="floaty-piece floaty-footer" src="../assets/images/pieces/staunty/wK.svg"/>
+            <img style="right: -70px;bottom: -35px;width: 200px;" class="floaty-piece floaty-footer" src="../assets/images/pieces/staunty/wK.svg" alt=""/>
             <section><a href="../tos">Terms of Service</a><a href="../privacy">Privacy Policy</a><a href="https://www.gnu.org/licenses/gpl-3.0.en.html">Licensed with GPLv3</a><a href="https://github.com/Hakorr">Contact Me</a></section>
         </footer>
     </main>
     <script async="" src="../assets/js/site-additional-content.js"></script>
-    <script async="" src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7248123202489335" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/development/index.html
+++ b/development/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>Development / A.C.A.S</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -22,7 +22,6 @@
     <meta property="og:type" content="website">
     <script type="text/javascript"src="../assets/js/tag-manager.js"></script>
     <script async="" type="text/javascript" src="https://www.googletagmanager.com/gtm.js?id=GTM-5499BQ4B"></script>
-    <script async="" type="text/javascript" src="../index.js"></script>
     <script defer="" type="text/javascript" src="../assets/libraries/klaro/config.js"></script>
     <script defer="" type="text/javascript" src="../assets/libraries/klaro/klaro.js"></script>
     <script async="" src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7248123202489335" crossorigin="anonymous"></script>
@@ -39,18 +38,18 @@
                 <a href="../faq/" aria-label="Frequently Asked Questions" class="fancy-btn"><i class="bi bi-chat-square-quote"></i>FAQ</a>
                 <a href="../blog/" aria-label="View A.C.A.S blog" class="fancy-btn"><i class="bi bi-pen"></i>Blog</a>
                 <a href="../contributing/" aria-label="Contribute to A.C.A.S" class="fancy-btn"><i class="bi bi-heart"></i></a>
-                <a href="https://github.com/psyyke/A.C.A.S" target="_blank" class="github-corner fancy-btn" aria-label="View source on Github"><i class="bi bi-github"></i></a>
+                <a href="https://github.com/psyyke/A.C.A.S" target="_blank" class="github-corner fancy-btn" aria-label="View source on Github" rel="noopener noreferrer"><i class="bi bi-github"></i></a>
             </div>
         </header>
         <div class="content">
-            <img style="right: -40px;width: 120px;top: -40px;transform: rotate(5deg);" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/wN.svg">
-            <img style="left: -60px;width: 140px;top: 130px;transform: rotate(-6deg);" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/bK.svg">
-            <img style="left: -155px;width: 150px;top: 0;filter: blur(3px);transform: rotate(26deg);opacity: 0.7;" class="floaty-piece floaty-mobile-fix floaty-subpage" src="../assets/images/pieces/staunty/wQ.svg">
-            <img style="right: -130px;width: 120px;top: 75px;filter: blur(4px);transform: rotate(-26deg);opacity: 0.65;" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/bK.svg">
-            <img style="right: -40px;width: 90px;top: 220px;transform: rotate(15deg);" class="floaty-piece floaty-subpage" src="../assets/images/pieces/staunty/bR.svg">
+            <img style="right: -40px;width: 120px;top: -40px;transform: rotate(5deg);" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/wN.svg" alt="">
+            <img style="left: -60px;width: 140px;top: 130px;transform: rotate(-6deg);" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/bK.svg" alt="">
+            <img style="left: -155px;width: 150px;top: 0;filter: blur(3px);transform: rotate(26deg);opacity: 0.7;" class="floaty-piece floaty-mobile-fix floaty-subpage" src="../assets/images/pieces/staunty/wQ.svg" alt="">
+            <img style="right: -130px;width: 120px;top: 75px;filter: blur(4px);transform: rotate(-26deg);opacity: 0.65;" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/bK.svg" alt="">
+            <img style="right: -40px;width: 90px;top: 220px;transform: rotate(15deg);" class="floaty-piece floaty-subpage" src="../assets/images/pieces/staunty/bR.svg" alt="">
             <!-- PAGE CONTENT -->
             <article class="markdown-section-sub markdown-section" id="main">
-                <article class="markdown-section" id="main">
+                <article class="markdown-section">
                     <section>
                         <h1 id="development">Development 🌱</h1>
                         <blockquote class="bordered">
@@ -86,11 +85,10 @@
             <!-- PAGE CONTENT ENDS -->
         </div>
         <footer>
-            <img style="right: -70px;bottom: -35px;width: 200px;" class="floaty-piece floaty-footer" src="../assets/images/pieces/staunty/wQ.svg"/>
+            <img style="right: -70px;bottom: -35px;width: 200px;" class="floaty-piece floaty-footer" src="../assets/images/pieces/staunty/wQ.svg" alt=""/>
             <section><a href="../tos">Terms of Service</a><a href="../privacy">Privacy Policy</a><a href="https://www.gnu.org/licenses/gpl-3.0.en.html">Licensed with GPLv3</a><a href="https://github.com/Hakorr">Contact Me</a></section>
         </footer>
     </main>
     <script async="" src="../assets/js/site-additional-content.js"></script>
-    <script async="" src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7248123202489335" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/faq/index.html
+++ b/faq/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>Frequently Asked Questions / A.C.A.S</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -22,7 +22,6 @@
     <meta property="og:type" content="website">
     <script type="text/javascript"src="../assets/js/tag-manager.js"></script>
     <script async="" type="text/javascript" src="https://www.googletagmanager.com/gtm.js?id=GTM-5499BQ4B"></script>
-    <script async="" type="text/javascript" src="../index.js"></script>
     <script defer="" type="text/javascript" src="../assets/libraries/klaro/config.js"></script>
     <script defer="" type="text/javascript" src="../assets/libraries/klaro/klaro.js"></script>
     <script async="" src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7248123202489335" crossorigin="anonymous"></script>
@@ -39,15 +38,15 @@
                 <a href="../faq/" aria-label="Frequently Asked Questions" class="fancy-btn"><i class="bi bi-chat-square-quote"></i>FAQ</a>
                 <a href="../blog/" aria-label="View A.C.A.S blog" class="fancy-btn"><i class="bi bi-pen"></i>Blog</a>
                 <a href="../contributing/" aria-label="Contribute to A.C.A.S" class="fancy-btn"><i class="bi bi-heart"></i></a>
-                <a href="https://github.com/psyyke/A.C.A.S" target="_blank" class="github-corner fancy-btn" aria-label="View source on Github"><i class="bi bi-github"></i></a>
+                <a href="https://github.com/psyyke/A.C.A.S" target="_blank" class="github-corner fancy-btn" aria-label="View source on Github" rel="noopener noreferrer"><i class="bi bi-github"></i></a>
             </div>
         </header>
         <div class="content">
-            <img style="right: -40px;width: 120px;top: -40px;transform: rotate(5deg);" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/wN.svg">
-            <img style="left: -60px;width: 140px;top: 130px;transform: rotate(-6deg);" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/bK.svg">
-            <img style="left: -155px;width: 150px;top: 0;filter: blur(3px);transform: rotate(26deg);opacity: 0.7;" class="floaty-piece floaty-mobile-fix floaty-subpage" src="../assets/images/pieces/staunty/wQ.svg">
-            <img style="right: -130px;width: 120px;top: 75px;filter: blur(4px);transform: rotate(-26deg);opacity: 0.65;" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/bK.svg">
-            <img style="right: -40px;width: 90px;top: 220px;transform: rotate(15deg);" class="floaty-piece floaty-subpage" src="../assets/images/pieces/staunty/bR.svg">
+            <img style="right: -40px;width: 120px;top: -40px;transform: rotate(5deg);" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/wN.svg" alt="">
+            <img style="left: -60px;width: 140px;top: 130px;transform: rotate(-6deg);" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/bK.svg" alt="">
+            <img style="left: -155px;width: 150px;top: 0;filter: blur(3px);transform: rotate(26deg);opacity: 0.7;" class="floaty-piece floaty-mobile-fix floaty-subpage" src="../assets/images/pieces/staunty/wQ.svg" alt="">
+            <img style="right: -130px;width: 120px;top: 75px;filter: blur(4px);transform: rotate(-26deg);opacity: 0.65;" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/bK.svg" alt="">
+            <img style="right: -40px;width: 90px;top: 220px;transform: rotate(15deg);" class="floaty-piece floaty-subpage" src="../assets/images/pieces/staunty/bR.svg" alt="">
             <!-- PAGE CONTENT -->
             <article class="markdown-section-sub markdown-section" id="main">
                 <section>
@@ -71,7 +70,7 @@
                             </p>
                             <p>
                                AI detection systems track these types of behavioral patterns to spot unfair play, so it's best to play honestly. Sooner or later <b>you will get banned</b> for following engine moves directly. Don't be that guy.
-                                For learning purposes, you can disable the <a target="_about" href="../app?shl=displayMovesOnExternalSite">Moves On External Site</a> setting to only see advice when you choose, allowing you to improve your skills naturally.
+                                For learning purposes, you can disable the <a target="_blank" href="../app?shl=displayMovesOnExternalSite" rel="noopener noreferrer">Moves On External Site</a> setting to only see advice when you choose, allowing you to improve your skills naturally.
                             </p>
                         </div>
                     </div>
@@ -147,11 +146,10 @@
             <!-- PAGE CONTENT ENDS -->
         </div>
         <footer>
-            <img style="right: -70px;bottom: -35px;width: 200px;" class="floaty-piece floaty-footer" src="../assets/images/pieces/staunty/wR.svg"/>
+            <img style="right: -70px;bottom: -35px;width: 200px;" class="floaty-piece floaty-footer" src="../assets/images/pieces/staunty/wR.svg" alt=""/>
             <section><a href="../tos">Terms of Service</a><a href="../privacy">Privacy Policy</a><a href="https://www.gnu.org/licenses/gpl-3.0.en.html">Licensed with GPLv3</a><a href="https://github.com/Hakorr">Contact Me</a></section>
         </footer>
     </main>
     <script async="" src="../assets/js/site-additional-content.js"></script>
-    <script async="" src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7248123202489335" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>A.C.A.S (Advanced Chess Assistance System)</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -19,7 +19,7 @@
     <link rel="stylesheet" type="text/css" href="assets/css/home.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css"/>
     <link rel="icon" type="image/x-icon" href="favicon.ico">
-    <link rel="canonical" href="https://psyyke.github.io">
+    <link rel="canonical" href="https://psyyke.github.io/A.C.A.S/">
     <meta property="og:type" content="website">
     <script type="text/javascript"src="assets/js/tag-manager.js"></script>
     <script async="" type="text/javascript" src="https://www.googletagmanager.com/gtm.js?id=GTM-5499BQ4B"></script>
@@ -31,7 +31,7 @@
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5499BQ4B" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <main>
         <header>
-            <div><a href="" class="acas-logo-main fancy-btn">A.C.A.S<span>V2</span></a></div>
+            <div><a href="./" class="acas-logo-main fancy-btn">A.C.A.S<span>V2</span></a></div>
             <div>
                 <a href="install/" aria-label="Install A.C.A.S" class="fancy-btn"><i class="bi bi-download"></i>Install</a>
                 <a href="usage/" aria-label="How to use A.C.A.S" class="fancy-btn"><i class="bi bi-journals"></i>Usage</a>
@@ -39,7 +39,7 @@
                 <a href="faq/" aria-label="Frequently Asked Questions" class="fancy-btn"><i class="bi bi-chat-square-quote"></i>FAQ</a>
                 <a href="blog/" aria-label="View A.C.A.S blog" class="fancy-btn"><i class="bi bi-pen"></i>Blog</a>
                 <a href="contributing/" aria-label="Contribute to A.C.A.S" class="fancy-btn"><i class="bi bi-heart"></i></a>
-                <a href="https://github.com/psyyke/A.C.A.S" target="_blank" class="github-corner fancy-btn" aria-label="View source on Github"><i class="bi bi-github"></i></a>
+                <a href="https://github.com/psyyke/A.C.A.S" target="_blank" class="github-corner fancy-btn" aria-label="View source on Github" rel="noopener noreferrer"><i class="bi bi-github"></i></a>
             </div>
         </header>
         <div class="content">
@@ -68,17 +68,17 @@
             .floaty4 { --floaty-rotate: 35deg; animation-delay: 1.2s; right: -90px; width: 120px; top: 840px; filter: blur(2px); opacity: 0.5; transform: rotate(35deg); z-index: -1; }
             .floaty10 { --floaty-rotate: -40deg; animation-delay: 2s; right: -25px; width: 60px; top: 790px; filter: blur(4px) brightness(0.8); opacity: 0.5; transform: rotate(-40deg); z-index: -1; }
             </style>
-            <img class="floaty-piece floaty-no-mobile floaty1" src="assets/images/pieces/staunty/wK.svg"/>
-            <img class="floaty-piece floaty-no-mobile floaty2" src="assets/images/pieces/staunty/bB.svg">
-            <img class="floaty-piece floaty-no-mobile floaty3" src="assets/images/pieces/staunty/wQ.svg"/>
-            <img class="floaty-piece floaty-no-mobile floaty4" src="assets/images/pieces/staunty/bP.svg"/>
-            <img class="floaty-piece floaty-no-mobile floaty5" src="assets/images/pieces/staunty/bR.svg">
-            <img class="floaty-piece floaty-no-mobile floaty6" src="assets/images/pieces/staunty/bP.svg"/>
-            <img class="floaty-piece floaty-no-mobile floaty7" src="assets/images/pieces/staunty/wR.svg"/>
-            <img class="floaty-piece floaty-no-mobile floaty9" src="assets/images/pieces/staunty/bK.svg"/>
-            <img class="floaty-piece floaty-no-mobile floaty8" src="assets/images/pieces/staunty/bQ.svg"/>
-            <img class="floaty-piece floaty-no-mobile floaty8" src="assets/images/pieces/staunty/wQ.svg"/>
-            <img class="floaty-piece floaty-no-mobile floaty10" src="assets/images/pieces/staunty/wR.svg"/>
+            <img class="floaty-piece floaty-no-mobile floaty1" src="assets/images/pieces/staunty/wK.svg" alt=""/>
+            <img class="floaty-piece floaty-no-mobile floaty2" src="assets/images/pieces/staunty/bB.svg" alt="">
+            <img class="floaty-piece floaty-no-mobile floaty3" src="assets/images/pieces/staunty/wQ.svg" alt=""/>
+            <img class="floaty-piece floaty-no-mobile floaty4" src="assets/images/pieces/staunty/bP.svg" alt=""/>
+            <img class="floaty-piece floaty-no-mobile floaty5" src="assets/images/pieces/staunty/bR.svg" alt="">
+            <img class="floaty-piece floaty-no-mobile floaty6" src="assets/images/pieces/staunty/bP.svg" alt=""/>
+            <img class="floaty-piece floaty-no-mobile floaty7" src="assets/images/pieces/staunty/wR.svg" alt=""/>
+            <img class="floaty-piece floaty-no-mobile floaty9" src="assets/images/pieces/staunty/bK.svg" alt=""/>
+            <img class="floaty-piece floaty-no-mobile floaty8" src="assets/images/pieces/staunty/bQ.svg" alt=""/>
+            <img class="floaty-piece floaty-no-mobile floaty0" src="assets/images/pieces/staunty/wQ.svg" alt=""/>
+            <img class="floaty-piece floaty-no-mobile floaty10" src="assets/images/pieces/staunty/wR.svg" alt=""/>
              <!-- PAGE CONTENT -->
             <article class="markdown-section" id="main">
                 <section class="main-first-section">
@@ -88,14 +88,14 @@
                     <img class="mock-img" src="assets/images/mock.webp" alt="A mockup image of the A.C.A.S software.">
                 </section>
                 <section class="stats-container bordered">
-                    <img style="left: -50px;width: 90px;top: -30px;transform: rotate(12deg);" class="floaty-piece" src="assets/images/pieces/staunty/wP.svg"/>
+                    <img style="left: -50px;width: 90px;top: -30px;transform: rotate(12deg);" class="floaty-piece" src="assets/images/pieces/staunty/wP.svg" alt=""/>
                     <div>
                         <div><h2>50 000+</h2><span>Installs</span></div>
                         <div><h2>2000</h2><span>Daily Users</span></div>
                         <div><h2>&gt;80%</h2><span>Positive Reviews</span></div>
                         <div><h2>100+</h2><span>Stars</span></div>
                     </div>
-                    <img style="right: -42px;width: 90px;bottom: -20px;transform: rotate(6deg);" class="floaty-piece floaty0" src="assets/images/pieces/staunty/bB.svg"/>
+                    <img style="right: -42px;width: 90px;bottom: -20px;transform: rotate(6deg);" class="floaty-piece floaty0" src="assets/images/pieces/staunty/bB.svg" alt=""/>
                 </section>
                 <section>
                     <p><b>A.C.A.S</b> (<i>Advanced Chess Assistance System</i>) is an open-source chess assistant (not a chess cheat), designed to help you make better moves using a chess engine. Just install the userscript, open the A.C.A.S GUI, and you're ready to go, no downloads necessary!</p>
@@ -156,11 +156,10 @@
             <!-- PAGE CONTENT ENDS -->
         </div>
         <footer>
-            <img style="right: -70px;bottom: -35px;width: 200px;" class="floaty-piece floaty-footer" src="assets/images/pieces/staunty/wN.svg"/>
+            <img style="right: -70px;bottom: -35px;width: 200px;" class="floaty-piece floaty-footer" src="assets/images/pieces/staunty/wN.svg" alt=""/>
             <section><a href="tos/">Terms of Service</a><a href="privacy/">Privacy Policy</a><a href="https://www.gnu.org/licenses/gpl-3.0.en.html">Licensed with GPLv3</a><a href="https://github.com/Hakorr">Contact Me</a></section>
         </footer>
     </main>
     <script async="" src="assets/js/site-additional-content.js"></script>
-    <script async="" src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7248123202489335" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/install/index.html
+++ b/install/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>Install / A.C.A.S</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -22,7 +22,6 @@
     <meta property="og:type" content="website">
     <script type="text/javascript"src="../assets/js/tag-manager.js"></script>
     <script async="" type="text/javascript" src="https://www.googletagmanager.com/gtm.js?id=GTM-5499BQ4B"></script>
-    <script async="" type="text/javascript" src="../index.js"></script>
     <script defer="" type="text/javascript" src="../assets/libraries/klaro/config.js"></script>
     <script defer="" type="text/javascript" src="../assets/libraries/klaro/klaro.js"></script>
     <script async="" src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7248123202489335" crossorigin="anonymous"></script>
@@ -39,19 +38,19 @@
                 <a href="../faq/" aria-label="Frequently Asked Questions" class="fancy-btn"><i class="bi bi-chat-square-quote"></i>FAQ</a>
                 <a href="../blog/" aria-label="View A.C.A.S blog" class="fancy-btn"><i class="bi bi-pen"></i>Blog</a>
                 <a href="../contributing/" aria-label="Contribute to A.C.A.S" class="fancy-btn"><i class="bi bi-heart"></i></a>
-                <a href="https://github.com/psyyke/A.C.A.S" target="_blank" class="github-corner fancy-btn" aria-label="View source on Github"><i class="bi bi-github"></i></a>
+                <a href="https://github.com/psyyke/A.C.A.S" target="_blank" class="github-corner fancy-btn" aria-label="View source on Github" rel="noopener noreferrer"><i class="bi bi-github"></i></a>
             </div>
         </header>
         <div class="content">
-            <img style="right: -40px;width: 120px;top: -40px;transform: rotate(5deg);" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/wN.svg">
-            <img style="left: -60px;width: 140px;top: 130px;transform: rotate(-6deg);" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/bK.svg">
-            <img style="left: -155px;width: 150px;top: 0;filter: blur(3px);transform: rotate(26deg);opacity: 0.7;" class="floaty-piece floaty-mobile-fix floaty-subpage" src="../assets/images/pieces/staunty/wQ.svg">
-            <img style="right: -130px;width: 120px;top: 75px;filter: blur(4px);transform: rotate(-26deg);opacity: 0.65;" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/bK.svg">
-            <img style="right: -40px;width: 90px;top: 220px;transform: rotate(15deg);" class="floaty-piece floaty-subpage" src="../assets/images/pieces/staunty/bR.svg">
+            <img style="right: -40px;width: 120px;top: -40px;transform: rotate(5deg);" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/wN.svg" alt="">
+            <img style="left: -60px;width: 140px;top: 130px;transform: rotate(-6deg);" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/bK.svg" alt="">
+            <img style="left: -155px;width: 150px;top: 0;filter: blur(3px);transform: rotate(26deg);opacity: 0.7;" class="floaty-piece floaty-mobile-fix floaty-subpage" src="../assets/images/pieces/staunty/wQ.svg" alt="">
+            <img style="right: -130px;width: 120px;top: 75px;filter: blur(4px);transform: rotate(-26deg);opacity: 0.65;" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/bK.svg" alt="">
+            <img style="right: -40px;width: 90px;top: 220px;transform: rotate(15deg);" class="floaty-piece floaty-subpage" src="../assets/images/pieces/staunty/bR.svg" alt="">
             <!-- PAGE CONTENT -->
             <article class="markdown-section-sub markdown-section" id="main">
                 <section>
-                    <h1 id="installation-📦">Installation 📦</h1><p>Simply open the <a target="_about" href="../app">GUI</a>, it will help you install A.C.A.S. More detailed information is below.</p>
+                    <h1 id="installation-📦">Installation 📦</h1><p>Simply open the <a target="_blank" href="../app" rel="noopener noreferrer">GUI</a>, it will help you install A.C.A.S. More detailed information is below.</p>
                 </section>
                 <section>
                     <h2 id="getting-started">Getting Started</h2>
@@ -68,16 +67,16 @@
                             Install A.C.A.S from <a href="https://greasyfork.org/en/scripts/459137-a-c-a-s-advanced-chess-assistance-system" target="_blank" rel="noopener">GreasyFork</a>. If you don't like GreasyFork for some reason, you can also manually create a new userscript on the manager and then copy paste the code from <code>acas.user.js</code> there.
                         </li>
                         <li>
-                            Open the <a target="_about" href="../app">GUI</a>. Follow the instructions.
+                            Open the <a target="_blank" href="../app" rel="noopener noreferrer">GUI</a>. Follow the instructions.
                         </li>
                         <li>
                             Open a supported chess site on <strong>another browser window next to the GUI</strong> and start playing.
                             <ul>
-                                <li>Alternatively, enable the <a target="_about" href="../app?shl=pip">Floating Panel</a> setting to prevent the GUI from freezing.</li>
+                                <li>Alternatively, enable the <a target="_blank" href="../app?shl=pip" rel="noopener noreferrer">Floating Panel</a> setting to prevent the GUI from freezing.</li>
                             </ul>
                         </li>
                     </ol>
-                    <p class="tip">Keep the A.C.A.S GUI tab active to keep the whole system functional. Think of the tab as an engine of a car, the userscript alone is simply an empty hull, it won't move. The GUI has the chess engine, it calculates the moves! Either make two browser windows next to each other or use the <a target="_about" href="../app?shl=pip">Floating Panel</a> setting.</p>
+                    <p class="tip">Keep the A.C.A.S GUI tab active to keep the whole system functional. Think of the tab as an engine of a car, the userscript alone is simply an empty hull, it won't move. The GUI has the chess engine, it calculates the moves! Either make two browser windows next to each other or use the <a target="_blank" href="../app?shl=pip" rel="noopener noreferrer">Floating Panel</a> setting.</p>
                 </section>
                 <section>
                     <h2 id="mobile-users">Mobile Users (& macOS)</h2>
@@ -90,11 +89,11 @@
                             </ul>
                         </li>
                         <li>Follow the <a href="#getting-started">Getting Started</a> guide found above.</li>
-                        <li>Make sure to enable <a target="_about" href="../app?shl=pip">Floating Panel</a> setting to prevent freezing.</li>
+                        <li>Make sure to enable <a target="_blank" href="../app?shl=pip" rel="noopener noreferrer">Floating Panel</a> setting to prevent freezing.</li>
                     </ol>
                 </section>
                 <section>
-                    <p>Note that you need to play games in the browser. For example, A.C.A.S won't work in the Chess app. It functions the same way as on a desktop, but the challenge is finding a browser that supports extensions like Violentmonkey. We've recommended a few options above.</p><p class="tip"><strong>Both users</strong> should enable the <a target="_about" href="../app?shl=pip">Floating Panel</a> setting to prevent A.C.A.S freezing and not giving suggestions. Every time you start A.C.A.S, make sure to click the A.C.A.S page once to open the <a target="_about" href="../app?shl=pip">Floating Panel</a>! The panel needs to be visible in order to stop freezing.</p>
+                    <p>Note that you need to play games in the browser. For example, A.C.A.S won't work in the Chess app. It functions the same way as on a desktop, but the challenge is finding a browser that supports extensions like Violentmonkey. We've recommended a few options above.</p><p class="tip"><strong>Both users</strong> should enable the <a target="_blank" href="../app?shl=pip" rel="noopener noreferrer">Floating Panel</a> setting to prevent A.C.A.S freezing and not giving suggestions. Every time you start A.C.A.S, make sure to click the A.C.A.S page once to open the <a target="_blank" href="../app?shl=pip" rel="noopener noreferrer">Floating Panel</a>! The panel needs to be visible in order to stop freezing.</p>
                 </section>
                 <section>
                     <h2 id="desktop">External Engines (Beta)</h2>
@@ -109,11 +108,10 @@
             <!-- PAGE CONTENT ENDS -->
         </div>
         <footer>
-            <img style="right: -70px;bottom: -35px;width: 200px;" class="floaty-piece floaty-footer" src="../assets/images/pieces/staunty/wP.svg"/>
+            <img style="right: -70px;bottom: -35px;width: 200px;" class="floaty-piece floaty-footer" src="../assets/images/pieces/staunty/wP.svg" alt=""/>
             <section><a href="../tos">Terms of Service</a><a href="../privacy">Privacy Policy</a><a href="https://www.gnu.org/licenses/gpl-3.0.en.html">Licensed with GPLv3</a><a href="https://github.com/Hakorr">Contact Me</a></section>
         </footer>
     </main>
     <script async="" src="../assets/js/site-additional-content.js"></script>
-    <script async="" src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7248123202489335" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <title>PRIVACY POLICY / A.C.A.S</title>
         <meta name="description" content="How A.C.A.S handles data and cookies. We don’t collect personal data directly; third‑party services may process data with your consent.">
@@ -15,7 +15,7 @@
             <div class="big-title">A.C.A.S PRIVACY POLICY</div>
         
             <div class="small-paragraph center-text greyed">Effective Date: 12/03/2025 (dd/mm/yyyy)</div>
-            <div class="small-paragraph extra-slim center-text">By using A.C.A.S, you agree to our <a href="../tos/" target="_blank">Terms of Service</a> and this Privacy Policy.</div>
+            <div class="small-paragraph extra-slim center-text">By using A.C.A.S, you agree to our <a href="../tos/" target="_blank" rel="noopener noreferrer">Terms of Service</a> and this Privacy Policy.</div>
         
             <div class="title">1. Data Collection</div>
             <div class="paragraph slim">
@@ -24,7 +24,7 @@
         
             <div class="title">2. Cookies</div>
             <div class="paragraph slim">
-                This website uses cookies for advertising and analytics. By using this website, you consent to the use of cookies. You may withdraw consent or opt out of personalized advertising at any time by visiting <a href="https://adssettings.google.com/" target="_blank">Google Ads Settings</a> or <a href="https://www.aboutads.info/" target="_blank">www.aboutads.info</a>.
+                This website uses cookies for advertising and analytics. By using this website, you consent to the use of cookies. You may withdraw consent or opt out of personalized advertising at any time by visiting <a href="https://adssettings.google.com/" target="_blank" rel="noopener noreferrer">Google Ads Settings</a> or <a href="https://www.aboutads.info/" target="_blank" rel="noopener noreferrer">www.aboutads.info</a>.
             </div>
         
             <table border="1" cellpadding="10">

--- a/tos/index.html
+++ b/tos/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <title>TERMS OF SERVICE / A.C.A.S</title>
         <meta name="description" content="Terms of Service for A.C.A.S: acceptable use, fair‑play restrictions, third‑party services, and liability.">
@@ -25,7 +25,7 @@
             <br><br>
             Before you start using A.C.A.S, remember that struggling at chess doesn't mean you're unintelligent... it's not an IQ test, just a board game. If you're <b>constantly</b> unable to take a defeat, you need mental health assistance more than chess assistance.
             <br><br>
-            If you're struggling with depression, addiction, gaming compulsions, or feeling stuck in cheating behavior, you're not alone and  <a href="https://findahelpline.com" target="_blank">help exists</a>. Reaching out early makes a difference. Please don't use A.C.A.S in an unstable state of mind.
+            If you're struggling with depression, addiction, gaming compulsions, or feeling stuck in cheating behavior, you're not alone and  <a href="https://findahelpline.com" target="_blank" rel="noopener noreferrer">help exists</a>. Reaching out early makes a difference. Please don't use A.C.A.S in an unstable state of mind.
             </div>
 
             <div class="title">2. Liability and Third-Party Services</div>

--- a/troubleshoot/index.html
+++ b/troubleshoot/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>Troubleshoot / A.C.A.S</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -22,7 +22,6 @@
     <meta property="og:type" content="website">
     <script type="text/javascript"src="../assets/js/tag-manager.js"></script>
     <script async="" type="text/javascript" src="https://www.googletagmanager.com/gtm.js?id=GTM-5499BQ4B"></script>
-    <script async="" type="text/javascript" src="../index.js"></script>
     <script defer="" type="text/javascript" src="../assets/libraries/klaro/config.js"></script>
     <script defer="" type="text/javascript" src="../assets/libraries/klaro/klaro.js"></script>
     <script async="" src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7248123202489335" crossorigin="anonymous"></script>
@@ -39,19 +38,19 @@
                 <a href="../faq/" aria-label="Frequently Asked Questions" class="fancy-btn"><i class="bi bi-chat-square-quote"></i>FAQ</a>
                 <a href="../blog/" aria-label="View A.C.A.S blog" class="fancy-btn"><i class="bi bi-pen"></i>Blog</a>
                 <a href="../contributing/" aria-label="Contribute to A.C.A.S" class="fancy-btn"><i class="bi bi-heart"></i></a>
-                <a href="https://github.com/psyyke/A.C.A.S" target="_blank" class="github-corner fancy-btn" aria-label="View source on Github"><i class="bi bi-github"></i></a>
+                <a href="https://github.com/psyyke/A.C.A.S" target="_blank" class="github-corner fancy-btn" aria-label="View source on Github" rel="noopener noreferrer"><i class="bi bi-github"></i></a>
             </div>
         </header>
         <div class="content">
-            <img style="right: -40px;width: 120px;top: -40px;transform: rotate(5deg);" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/wN.svg">
-            <img style="left: -60px;width: 140px;top: 130px;transform: rotate(-6deg);" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/bK.svg">
-            <img style="left: -155px;width: 150px;top: 0;filter: blur(3px);transform: rotate(26deg);opacity: 0.7;" class="floaty-piece floaty-mobile-fix floaty-subpage" src="../assets/images/pieces/staunty/wQ.svg">
-            <img style="right: -130px;width: 120px;top: 75px;filter: blur(4px);transform: rotate(-26deg);opacity: 0.65;" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/bK.svg">
-            <img style="right: -40px;width: 90px;top: 220px;transform: rotate(15deg);" class="floaty-piece floaty-subpage" src="../assets/images/pieces/staunty/bR.svg">
+            <img style="right: -40px;width: 120px;top: -40px;transform: rotate(5deg);" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/wN.svg" alt="">
+            <img style="left: -60px;width: 140px;top: 130px;transform: rotate(-6deg);" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/bK.svg" alt="">
+            <img style="left: -155px;width: 150px;top: 0;filter: blur(3px);transform: rotate(26deg);opacity: 0.7;" class="floaty-piece floaty-mobile-fix floaty-subpage" src="../assets/images/pieces/staunty/wQ.svg" alt="">
+            <img style="right: -130px;width: 120px;top: 75px;filter: blur(4px);transform: rotate(-26deg);opacity: 0.65;" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/bK.svg" alt="">
+            <img style="right: -40px;width: 90px;top: 220px;transform: rotate(15deg);" class="floaty-piece floaty-subpage" src="../assets/images/pieces/staunty/bR.svg" alt="">
             <!-- PAGE CONTENT -->
             <article class="markdown-section-sub markdown-section" id="main">
             <section>
-                <h1 id="troubleshoot-🛠️">Troubleshoot 🛠️</h1><p class="tip">Browsers freeze code execution on inactive pages, you need to visit the GUI tab from time to time, <strong>keep it at least partly visible on a separate window</strong> or <strong>use the <a target="_about" href="../app?shl=pip">Floating Panel</a> setting</strong>. This prevents A.C.A.S from freezing and not giving any move suggestions.</p>
+                <h1 id="troubleshoot-🛠️">Troubleshoot 🛠️</h1><p class="tip">Browsers freeze code execution on inactive pages, you need to visit the GUI tab from time to time, <strong>keep it at least partly visible on a separate window</strong> or <strong>use the <a target="_blank" href="../app?shl=pip" rel="noopener noreferrer">Floating Panel</a> setting</strong>. This prevents A.C.A.S from freezing and not giving any move suggestions.</p>
             </section>
             <section>
             <h2>External Server</h2>
@@ -61,7 +60,7 @@
             <ol>
                 <li><strong>Google Chrome / Edge</strong>
                     <ul>
-                        <li>Click the lock/config icon in the address bar → <a href="chrome://settings/content/siteDetails?site=https%3A%2F%2Fpsyyke.github.io" target="_blank"><strong>Site settings</strong></a>.</li>
+                        <li>Click the lock/config icon in the address bar → <a href="chrome://settings/content/siteDetails?site=https%3A%2F%2Fpsyyke.github.io" target="_blank" rel="noopener noreferrer"><strong>Site settings</strong></a>.</li>
                         <li>Enable <strong>Local network access</strong> and <strong>Installable / Apps on device</strong> permissions.</li>
                     </ul>
                 </li>
@@ -83,8 +82,8 @@
                 <h2 id="not-working">Not Working</h2>
                 <p>Before <a href="https://github.com/Psyyke/A.C.A.S/issues" target="_blank" rel="noopener">making an issue</a>, please read these.</p>
                 <ul>
-                    <li><p>Make sure the <a target="_about" href="../app">GUI</a> is active. Do not close the tab.</p></li>
-                    <li><p>Not seeing any moves displayed on the chess site? Are you sure you have enabled the <a target="_about" href="../app?shl=displayMovesOnExternalSite">Display Moves On External Site</a> setting? After enabling that setting, please refresh the chess site to see changes.</p></li>
+                    <li><p>Make sure the <a target="_blank" href="../app" rel="noopener noreferrer">GUI</a> is active. Do not close the tab.</p></li>
+                    <li><p>Not seeing any moves displayed on the chess site? Are you sure you have enabled the <a target="_blank" href="../app?shl=displayMovesOnExternalSite" rel="noopener noreferrer">Display Moves On External Site</a> setting? After enabling that setting, please refresh the chess site to see changes.</p></li>
                     <li><p>Are you trying to play variants on Chess.com? If so, it's not currently supported very well since I had to rush the project, sorry! Other sites with variants might also be buggy, you can make an issue about that if you want.</p></li>
                     <li><p>Make sure you did <strong>NOT</strong> set "<em>Piece Animations</em>" to "<em>Arcade</em>" on <strong>Chess.com</strong> board settings! Set the "<em>Piece Animations</em>" to "<em>None</em>" so that A.C.A.S can parse the board correctly. Thanks!</p></li>
                     <li>
@@ -116,11 +115,10 @@
             <!-- PAGE CONTENT ENDS -->
         </section>
         <footer>
-            <img style="right: -70px;bottom: -35px;width: 200px;" class="floaty-piece floaty-footer" src="../assets/images/pieces/staunty/wP.svg"/>
+            <img style="right: -70px;bottom: -35px;width: 200px;" class="floaty-piece floaty-footer" src="../assets/images/pieces/staunty/wP.svg" alt=""/>
             <section><a href="../tos">Terms of Service</a><a href="../privacy">Privacy Policy</a><a href="https://www.gnu.org/licenses/gpl-3.0.en.html">Licensed with GPLv3</a><a href="https://github.com/Hakorr">Contact Me</a></section>
         </footer>
     </main>
     <script async="" src="../assets/js/site-additional-content.js"></script>
-    <script async="" src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7248123202489335" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/usage/index.html
+++ b/usage/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>Usage / A.C.A.S</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -23,7 +23,6 @@
     <script type="text/javascript"src="../assets/js/tag-manager.js"></script>
     <script src="../assets/libraries/bodymovin/lottie.js" type="text/javascript"></script>
     <script async="" type="text/javascript" src="https://www.googletagmanager.com/gtm.js?id=GTM-5499BQ4B"></script>
-    <script async="" type="text/javascript" src="../index.js"></script>
     <script defer="" type="text/javascript" src="../assets/libraries/klaro/config.js"></script>
     <script defer="" type="text/javascript" src="../assets/libraries/klaro/klaro.js"></script>
     <script async="" src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7248123202489335" crossorigin="anonymous"></script>
@@ -40,20 +39,20 @@
                 <a href="../faq/" aria-label="Frequently Asked Questions" class="fancy-btn"><i class="bi bi-chat-square-quote"></i>FAQ</a>
                 <a href="../blog/" aria-label="View A.C.A.S blog" class="fancy-btn"><i class="bi bi-pen"></i>Blog</a>
                 <a href="../contributing/" aria-label="Contribute to A.C.A.S" class="fancy-btn"><i class="bi bi-heart"></i></a>
-                <a href="https://github.com/psyyke/A.C.A.S" target="_blank" class="github-corner fancy-btn" aria-label="View source on Github"><i class="bi bi-github"></i></a>
+                <a href="https://github.com/psyyke/A.C.A.S" target="_blank" class="github-corner fancy-btn" aria-label="View source on Github" rel="noopener noreferrer"><i class="bi bi-github"></i></a>
             </div>
         </header>
         <div class="content">
-            <img style="right: -40px;width: 120px;top: -40px;transform: rotate(5deg);" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/wN.svg">
-            <img style="left: -60px;width: 140px;top: 130px;transform: rotate(-6deg);" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/bK.svg">
-            <img style="left: -155px;width: 150px;top: 0;filter: blur(3px);transform: rotate(26deg);opacity: 0.7;" class="floaty-piece floaty-mobile-fix floaty-subpage" src="../assets/images/pieces/staunty/wQ.svg">
-            <img style="right: -130px;width: 120px;top: 75px;filter: blur(4px);transform: rotate(-26deg);opacity: 0.65;" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/bK.svg">
-            <img style="right: -40px;width: 90px;top: 220px;transform: rotate(15deg);" class="floaty-piece floaty-subpage" src="../assets/images/pieces/staunty/bR.svg">
+            <img style="right: -40px;width: 120px;top: -40px;transform: rotate(5deg);" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/wN.svg" alt="">
+            <img style="left: -60px;width: 140px;top: 130px;transform: rotate(-6deg);" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/bK.svg" alt="">
+            <img style="left: -155px;width: 150px;top: 0;filter: blur(3px);transform: rotate(26deg);opacity: 0.7;" class="floaty-piece floaty-mobile-fix floaty-subpage" src="../assets/images/pieces/staunty/wQ.svg" alt="">
+            <img style="right: -130px;width: 120px;top: 75px;filter: blur(4px);transform: rotate(-26deg);opacity: 0.65;" class="floaty-piece floaty-no-mobile floaty-subpage" src="../assets/images/pieces/staunty/bK.svg" alt="">
+            <img style="right: -40px;width: 90px;top: 220px;transform: rotate(15deg);" class="floaty-piece floaty-subpage" src="../assets/images/pieces/staunty/bR.svg" alt="">
             <!-- PAGE CONTENT -->
             <article class="markdown-section-sub markdown-section" id="main">
                 <section>
                     <h1 id="usage-📖">Usage 📖</h1>
-                    <p>Using A.C.A.S is easy! Once you have the userscript installed, just keep the <a target="_blank" href="../app">GUI</a> open while you're playing on a chess site. By default, the moves it suggests will show up directly on the board you're playing on.</p>
+                    <p>Using A.C.A.S is easy! Once you have the userscript installed, just keep the <a target="_blank" href="../app" rel="noopener noreferrer">GUI</a> open while you're playing on a chess site. By default, the moves it suggests will show up directly on the board you're playing on.</p>
                     <p class="tip">Press Ctrl+D (Cmd+D for Mac) to bookmark this page.</p>
                     <div id="lottie-animation"></div>
                 </section>
@@ -94,12 +93,12 @@
                     </ul>
                     
                     <blockquote class="bordered">
-                        <p>⚠️ This list might be outdated. Check out the supported sites by clicking on the <a target="_blank" href="../app?hl=supportedSites">see all supported sites</a> button.</p>
+                        <p>⚠️ This list might be outdated. Check out the supported sites by clicking on the <a target="_blank" href="../app?hl=supportedSites" rel="noopener noreferrer">see all supported sites</a> button.</p>
                     </blockquote>
                 </section>
                 <section>
                     <h2 id="languages">🌐 Languages</h2><img alt="A.C.A.S translated to Japanese." height="267" src="../assets/images/example5.png">
-                    <p>You can change the language using the flag dropdown found on the top right on the <a target="_blank" href="../app">GUI</a>.</p>
+                    <p>You can change the language using the flag dropdown found on the top right on the <a target="_blank" href="../app" rel="noopener noreferrer">GUI</a>.</p>
                 </section>
                 <section>
                     <h2 id="external">🔥 Running External Engines (Beta)</h2>
@@ -115,9 +114,9 @@
 
                     <h3>Getting started with the server</h3>
                     <ol>
-                        <li><p class="tweaking" style="width: fit-content;"><a target="_blank" href="https://github.com/Psyyke/A.C.A.S/releases">Download Calculation Server</a></p><small>(Or compile it yourself, then open it)</small></li>
+                        <li><p class="tweaking" style="width: fit-content;"><a target="_blank" href="https://github.com/Psyyke/A.C.A.S/releases" rel="noopener noreferrer">Download Calculation Server</a></p><small>(Or compile it yourself, then open it)</small></li>
                         <li><p>Click "Add Engine Binary" button to add your chess engine.</p><small>(Windows users should look for .exe)</small></li>
-                        <li><p>Enable the <a target="_blank" href="../app?shl=useExternalChessEngine">External Chess Engine</a> on the GUI.</p><small>(Otherwise A.C.A.S will use a built-in engine)</small></li>
+                        <li><p>Enable the <a target="_blank" href="../app?shl=useExternalChessEngine" rel="noopener noreferrer">External Chess Engine</a> on the GUI.</p><small>(Otherwise A.C.A.S will use a built-in engine)</small></li>
                         <li><p>You will see your engines as list on the GUI. Click to select the engine you want to use.</p><small>(Remember to add engines using step 2 to be able to see them)</small></li>
                     </ol>
 
@@ -145,7 +144,7 @@
                     <ol>
                         <li><strong>Google Chrome / Edge</strong>
                             <ul>
-                                <li>Click the lock/config icon in the address bar → <a href="chrome://settings/content/siteDetails?site=https%3A%2F%2Fpsyyke.github.io" target="_blank"><strong>Site settings</strong></a>.</li>
+                                <li>Click the lock/config icon in the address bar → <a href="chrome://settings/content/siteDetails?site=https%3A%2F%2Fpsyyke.github.io" target="_blank" rel="noopener noreferrer"><strong>Site settings</strong></a>.</li>
                                 <li>Enable <strong>Local network access</strong> and <strong>Installable / Apps on device</strong> permissions.</li>
                             </ul>
                         </li>
@@ -167,12 +166,12 @@
                     <h2 id="settings">⚙️ Settings</h2>
 
                     <h3 id="⚙️-floating-panel">⚙️ Floating Panel</h3>
-                    <p>The <a target="_blank" href="../app?shl=pip">Floating Panel</a> setting creates a small "<em>Picture-in-Picture</em>" view you can resize to be even smaller that will stay on top of every window. It contains important information about the current match.</p>
+                    <p>The <a target="_blank" href="../app?shl=pip" rel="noopener noreferrer">Floating Panel</a> setting creates a small "<em>Picture-in-Picture</em>" view you can resize to be even smaller that will stay on top of every window. It contains important information about the current match.</p>
                     <p class="tip">This setting is very important to know because it stops A.C.A.S from freezing, and makes the engine run faster!</p>
                     <p>For Chromium based browsers, such as Chrome, disabling the floating panel creates a "mediaSession" which plays silent audio in loop to keep A.C.A.S active, even when not viewing the tab. Please keep in mind that you need to interact with the A.C.A.S GUI everytime you open it, so that this feature activates.</p>
                     <p>If you don't want to use the floating panel, you can also create two browser windows (tabs) next to each other, so that the A.C.A.S tab is visible, even if just a little bit, which also stops the A.C.A.S tab from freezing.</p>
                     <h3 id="⚙️-chess-engine">⚙️ Chess Engine</h3>
-                    <p>The <a target="_blank" href="../app?shl=chessEngine">Chess Engine</a> setting changes the engine which is used to calculate moves. We recommend using <strong>Stockfish 17 Lite</strong> as its the fastest and basically strongest engine, although it does not play like a human and has a hard time playing badly. If you want to play chess variants, use <strong>Fairy Stockfish 14</strong>.</p>
+                    <p>The <a target="_blank" href="../app?shl=chessEngine" rel="noopener noreferrer">Chess Engine</a> setting changes the engine which is used to calculate moves. We recommend using <strong>Stockfish 17 Lite</strong> as its the fastest and basically strongest engine, although it does not play like a human and has a hard time playing badly. If you want to play chess variants, use <strong>Fairy Stockfish 14</strong>.</p>
                     <ul>
                         <li>Stockfish &lt;17 (The strongest gameplay)</li>
                         <li>Fairy Stockfish 14 (Chess variants)</li>
@@ -185,16 +184,16 @@
                     <p>None of these engines will play like a human for you. Do not think you can get away playing 2500 ELO matches as a 1000 ELO player with an engine. We do not want to hear any complaining on why you got banned when you broke our ToS.</p>
 
                     <h3 id="⚙️-chess-variant">⚙️ Chess Variant</h3>
-                    <p class="tip">Most users do not play chess variants, <strong>you most likely do not need to change this nor the <a target="_blank" href="../app?shl=useChess960">Chess 960</a></strong>. If you happen to play a variant, A.C.A.S should automatically detect the chess variant you're playing if its supported.</p>
-                    <p>The <a target="_blank" href="../app?shl=chessVariant">Chess Variant</a> setting changes the type of chess Fairy Stockfish plays. Other engines don’t really support it, but most do support <a target="_blank" href="../app?shl=useChess960">Chess 960</a>, which is a variant of chess in which the piece starting positions are randomized. If you happen to play variants, you need to use Fairy Stockfish <a target="_blank" href="../app?shl=chessEngine">Chess Engine</a>.</p>
+                    <p class="tip">Most users do not play chess variants, <strong>you most likely do not need to change this nor the <a target="_blank" href="../app?shl=useChess960" rel="noopener noreferrer">Chess 960</a></strong>. If you happen to play a variant, A.C.A.S should automatically detect the chess variant you're playing if its supported.</p>
+                    <p>The <a target="_blank" href="../app?shl=chessVariant" rel="noopener noreferrer">Chess Variant</a> setting changes the type of chess Fairy Stockfish plays. Other engines don’t really support it, but most do support <a target="_blank" href="../app?shl=useChess960" rel="noopener noreferrer">Chess 960</a>, which is a variant of chess in which the piece starting positions are randomized. If you happen to play variants, you need to use Fairy Stockfish <a target="_blank" href="../app?shl=chessEngine" rel="noopener noreferrer">Chess Engine</a>.</p>
                     
                     <h3 id="⚙️-engine-elo">⚙️ Engine Elo</h3>
-                    <p>The <a target="_blank" href="../app?shl=engineElo">Engine Elo</a> setting controls how strong the engine plays (between 500-3200 ELO). Note that engines like Stockfish are <strong>very strong</strong>, playing way above human 3000 ELO. For that reason, making them play at low ELO (below 2000) might result in weird behaviour. The "Maia 2" engine is better suited for that.</p>
+                    <p>The <a target="_blank" href="../app?shl=engineElo" rel="noopener noreferrer">Engine Elo</a> setting controls how strong the engine plays (between 500-3200 ELO). Note that engines like Stockfish are <strong>very strong</strong>, playing way above human 3000 ELO. For that reason, making them play at low ELO (below 2000) might result in weird behaviour. The "Maia 2" engine is better suited for that.</p>
                     
                     <img alt="Chart displaying the ELO depending on the engine search depth and skill level." height="441" src="../assets/images/chart.png">
 
                     <h4>⚙️ Advanced Elo</h4>
-                    <p>The above chart shows a couple variables A.C.A.S changes for you automatically when you use the basic <a target="_blank" href="../app?shl=engineElo">Engine Elo</a> setting.
+                    <p>The above chart shows a couple variables A.C.A.S changes for you automatically when you use the basic <a target="_blank" href="../app?shl=engineElo" rel="noopener noreferrer">Engine Elo</a> setting.
                     Some users don't like it, so clicking the settings button next to the Engine ELO opens up "Advanced Elo" settings which overrides basic ELO settings. These are loaded dynamically when your engine starts, so you might not see any settings there while you have no instances running. It might also be buggy so refresh the site.
                     </p>
 
@@ -203,18 +202,18 @@
                     <p>Feel free to play around and try different things. If you notice something is not working, please understand that the dynamic nature of these settings causes bugs and not everything can be tested beforehand. If you're using a custom engine and encounter them, please feel free to report them to GitHub.</p>
             
                     <h3 id="⚙️-weights">⚙️ Weights</h3>
-                    <p>The <a target="_blank" href="../app?shl=lc0Weight">Lc0 Weights</a> setting determines how the Lc0 engine plays. The weight controls the engine's playing style, influencing the decisions it makes while playing. <strong>Maia weights</strong> have the ELO they're roughly playing at marked on them. The ELO and playing style of other weights is not known, but most of them are quite weak.</p>
+                    <p>The <a target="_blank" href="../app?shl=lc0Weight" rel="noopener noreferrer">Lc0 Weights</a> setting determines how the Lc0 engine plays. The weight controls the engine's playing style, influencing the decisions it makes while playing. <strong>Maia weights</strong> have the ELO they're roughly playing at marked on them. The ELO and playing style of other weights is not known, but most of them are quite weak.</p>
                     <p class="tip">Most weights A.C.A.S has, Maia specifically, are designed to only use 1 search node. It's fine that it goes just to depth 1. Using more than 1 search node might cause weird behavior.</p>
                     
                     <h3 id="⚙️-moves-on-external-site">⚙️ Moves On External Site</h3>
-                    <p>The <a target="_blank" href="../app?shl=displayMovesOnExternalSite">Moves On External Site</a> setting adds details about the move (<em>such has the arrow</em>) to the external site, which could be Chess.com for example, directly on the board you're playing on.</p>
+                    <p>The <a target="_blank" href="../app?shl=displayMovesOnExternalSite" rel="noopener noreferrer">Moves On External Site</a> setting adds details about the move (<em>such has the arrow</em>) to the external site, which could be Chess.com for example, directly on the board you're playing on.</p>
                     <p class="tip">Chess sites <em>could</em> implement detections to this. Right now no site seems to detect it, but if you're extra worried, disable this, it doesn't matter if you're not following the engine moves.</p>
                     
                     <h3 id="⚙️-theme-color">⚙️ Theme Color</h3>
-                    <p><a target="_blank" href="../app?shl=themeColorHex">Theme Color</a> setting and the settings below it allow you to change the theme to your liking.</p>
+                    <p><a target="_blank" href="../app?shl=themeColorHex" rel="noopener noreferrer">Theme Color</a> setting and the settings below it allow you to change the theme to your liking.</p>
                     <p>🟩 Best Move, 🟦 Secondary Move, 🟥 Enemy Move</p>
                     <blockquote class="bordered">
-                        <p>Enemy move is shown if <a target="_blank" href="../app?shl=showOpponentMoveGuess">Opponent Move Guess</a> setting is activated and the square an arrow starts from is hovered. The enemy move arrow is just a guess made by the engine and means that the engine thinks after you make the move the arrow suggests, the enemy will make the move the enemy arrow suggests.</p>
+                        <p>Enemy move is shown if <a target="_blank" href="../app?shl=showOpponentMoveGuess" rel="noopener noreferrer">Opponent Move Guess</a> setting is activated and the square an arrow starts from is hovered. The enemy move arrow is just a guess made by the engine and means that the engine thinks after you make the move the arrow suggests, the enemy will make the move the enemy arrow suggests.</p>
                     </blockquote>
             
                     <h2 id="render-settings">⚙️ Render Settings</h2>
@@ -228,14 +227,14 @@
                     </blockquote>
                     
                     <h3 id="⚙️-contested-squares">⚙️ Contested Squares</h3>
-                    <p>The <a target="_blank" href="../app?shl=renderSquareContested">Contested Squares</a> setting displays contested squares with the color orange. For clarity, fire emojis 🔥 indicate <strong>contested squares</strong> too. If two fire emojis are stacked it means there are 4 or 5 pieces attacking that square. 3 fire emojis stacked mean there are 6 or 7 pieces attacking that square, 4 fire emojis mean that 8 or 9 pieces are attacking it, and so fourth.</p>
+                    <p>The <a target="_blank" href="../app?shl=renderSquareContested" rel="noopener noreferrer">Contested Squares</a> setting displays contested squares with the color orange. For clarity, fire emojis 🔥 indicate <strong>contested squares</strong> too. If two fire emojis are stacked it means there are 4 or 5 pieces attacking that square. 3 fire emojis stacked mean there are 6 or 7 pieces attacking that square, 4 fire emojis mean that 8 or 9 pieces are attacking it, and so fourth.</p>
                     <p>The fire emoji can have text, for example, 🔥 with -2 text means that the square is defended by 2 less pieces than the enemy attacks it with (e.g. you have 1 piece defending the square, the enemy has 3 pieces attacking it, so 1 - 3 = -2). +2 means that you have 2 more pieces attacking the specific square than the enemy does (e.g. you attack a square with 4 pieces and the enemy defends it with only 2, so 4 - 2 = 2).</p>
                     
                     <h3 id="⚙️-own-piece-capture">⚙️ Own Piece Capture</h3>
-                    <p>The <a target="_blank" href="../app?shl=renderPiecePlayerCapture">Own Piece Capture</a> setting displays your vulnerable pieces. The teardrop emoji 💧 appears on <strong>your pieces</strong> which are vulnerable to attack. It takes into account the value of the pieces, so it doesn't appear if, for example, an enemy <strong>Queen</strong> attacks your <strong>Rook</strong> which is protected. However, if an enemy <strong>Rook</strong> was to attack your <strong>Queen</strong>, 💧 would appear on your <strong>Queen</strong>.</p>
+                    <p>The <a target="_blank" href="../app?shl=renderPiecePlayerCapture" rel="noopener noreferrer">Own Piece Capture</a> setting displays your vulnerable pieces. The teardrop emoji 💧 appears on <strong>your pieces</strong> which are vulnerable to attack. It takes into account the value of the pieces, so it doesn't appear if, for example, an enemy <strong>Queen</strong> attacks your <strong>Rook</strong> which is protected. However, if an enemy <strong>Rook</strong> was to attack your <strong>Queen</strong>, 💧 would appear on your <strong>Queen</strong>.</p>
                     
                     <h3 id="⚙️-enemy-piece-capture">⚙️ Enemy Piece Capture</h3>
-                    <p>The <a target="_blank" href="../app?shl=renderPieceEnemyCapture">Enemy Piece Capture</a> setting displays vulnerable enemy pieces. The bleed emoji 🩸 appears on <strong>enemy pieces</strong> which are vulnerable to attack. It takes into account the value of the pieces, so it doesn't appear if, for example, your <strong>Queen</strong> attacks an enemy <strong>Rook</strong> which is protected. However, if your <strong>Rook</strong> was to attack an enemy <strong>Queen</strong>, 🩸 would appear on the enemy <strong>Queen</strong>.</p>
+                    <p>The <a target="_blank" href="../app?shl=renderPieceEnemyCapture" rel="noopener noreferrer">Enemy Piece Capture</a> setting displays vulnerable enemy pieces. The bleed emoji 🩸 appears on <strong>enemy pieces</strong> which are vulnerable to attack. It takes into account the value of the pieces, so it doesn't appear if, for example, your <strong>Queen</strong> attacks an enemy <strong>Rook</strong> which is protected. However, if your <strong>Rook</strong> was to attack an enemy <strong>Queen</strong>, 🩸 would appear on the enemy <strong>Queen</strong>.</p>
                 </section>
                 <section>
                     <hr>
@@ -246,11 +245,10 @@
             <!-- PAGE CONTENT ENDS -->
         </div>
         <footer>
-            <img style="right: -70px;bottom: -35px;width: 200px;" class="floaty-piece floaty-footer" src="../assets/images/pieces/staunty/wB.svg"/>
+            <img style="right: -70px;bottom: -35px;width: 200px;" class="floaty-piece floaty-footer" src="../assets/images/pieces/staunty/wB.svg" alt=""/>
             <section><a href="../tos">Terms of Service</a><a href="../privacy">Privacy Policy</a><a href="https://www.gnu.org/licenses/gpl-3.0.en.html">Licensed with GPLv3</a><a href="https://github.com/Hakorr">Contact Me</a></section>
         </footer>
     </main>
     <script async="" src="../assets/js/site-additional-content.js"></script>
-    <script async="" src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7248123202489335" crossorigin="anonymous"></script>
 </body>
 </html>


### PR DESCRIPTION
8 pages load index.js, which was deleted but never removed from the markup. /board/ loads two more that don’t exist, so window.ChessgroundX never gets defined and the page stays blank - it’s the debug viewer linked from Interface.js. Checked in a headless browser: 0 pieces and two 404s before, renders clean after.

Also: adsbygoogle included twice on 8 pages (Google errors on the second head tag), the homepage canonical pointed at the Pages user root instead of /A.C.A.S/, 25 target=”_about” links (not a valid keyword, so they all reuse one window), 97 _blank links without rel=noopener - privacy/ and tos/ are the only pages that don’t load the runtime fixer, so there it was real. Plus duplicate id=“main”, two queens sharing floaty8, an empty logo href, and missing lang/alt attributes.