### PR TITLE
remove unused helpers and no-op assignments

### DIFF
--- a/acas.user.js
+++ b/acas.user.js
@@ -368,7 +368,6 @@ let activeMetricRenders = [];
 let activeFeedback = [];
 let boardObserver = null;
 let dumbBoardObservingInterval = null;
-let lastMutationObservationDate = 0;
 let lastCalculatedFullFen = null;
 let lastBoardRanks = null;
 let lastBoardFiles = null;
@@ -841,7 +840,6 @@ const boardUtils = {
                     lineWidth = lineWidth * arrowScale;
                     arrowheadWidth = arrowheadWidth * arrowScale;
                     arrowheadHeight = arrowheadHeight * arrowScale;
-                    startOffset = startOffset;
                 }
 
                 playerArrowElem = BoardDrawer.createShape('arrow', [from, to],
@@ -988,7 +986,6 @@ function extractElemTransformData(elem) {
 }
 
 function getElemCoordinatesFromTransform(elem, config) {
-    const onlyFlipX = config?.onlyFlipX;
     const onlyFlipY = config?.onlyFlipY;
 
     lastBoardSize = getElementSize(chessBoardElem);
@@ -1016,32 +1013,6 @@ function getElemCoordinatesFromTransform(elem, config) {
         const flippedX = lastBoardRanks - normalizedX - 1;
 
         return [flippedX, normalizedY];
-    }
-}
-
-function getElemCoordinatesFromLeftBottomPercentages(elem) {
-    if(!lastBoardRanks || !lastBoardFiles) {
-        const [files, ranks] = getBoardDimensions();
-
-        lastBoardRanks = ranks;
-        lastBoardFiles = files;
-    }
-
-    const boardOrientation = getBoardOrientation();
-
-    const leftPercentage = parseFloat(elem.style.left?.replace('%', ''));
-    const bottomPercentage = parseFloat(elem.style.bottom?.replace('%', ''));
-
-    const x = Math.max(Math.round(leftPercentage / (100 / lastBoardRanks)), 0);
-    const y = Math.max(Math.round(bottomPercentage / (100 / lastBoardFiles)), 0);
-
-    if (boardOrientation === 'w') {
-        return [x, y];
-    } else {
-        const flippedX = lastBoardRanks - (x + 1);
-        const flippedY = lastBoardFiles - (y + 1);
-
-        return [flippedX, flippedY];
     }
 }
 
@@ -1910,14 +1881,6 @@ function getBoardOrientation() {
     return playerColor;
 }
 
-function getFenPieceColor(pieceFenStr) {
-    return pieceFenStr == pieceFenStr.toUpperCase() ? 'w' : 'b';
-}
-
-function getFenPieceOppositeColor(pieceFenStr) {
-    return getFenPieceColor(pieceFenStr) == 'w' ? 'b' : 'w';
-}
-
 function convertPieceStrToFen(str) {
     if(!str || str.length !== 2) {
         return null;
@@ -1933,69 +1896,6 @@ function convertPieceStrToFen(str) {
     }
 
     return null;
-}
-
-function getCanvasPixelColor(canvas, [xPercentage, yPercentage], debug) {
-    const ctx = canvas.getContext('2d');
-
-    const x = xPercentage * canvas.width;
-    const y = yPercentage * canvas.height;
-
-    const imageData = ctx.getImageData(x, y, 1, 1);
-    const pixel = imageData.data;
-    const brightness = (pixel[0] + pixel[1] + pixel[2]) / 3;
-
-    if(debug) {
-        const clonedCanvas = document.createElement('canvas');
-                clonedCanvas.width = canvas.width;
-                clonedCanvas.height = canvas.height;
-
-        const clonedCtx = clonedCanvas.getContext('2d');
-                clonedCtx.drawImage(canvas, 0, 0);
-
-        clonedCtx.fillStyle = 'red';
-        clonedCtx.beginPath();
-        clonedCtx.arc(x, y, 1, 0, Math.PI * 2);
-        clonedCtx.fill();
-
-        const dataURL = clonedCanvas.toDataURL();
-
-        //console.log(canvas, pixel, dataURL);
-    }
-
-    return brightness < 128 ? 'b' : 'w';
-}
-
-function canvasHasPixelAt(canvas, [xPercentage, yPercentage], debug) {
-    xPercentage = Math.min(Math.max(xPercentage, 0), 100);
-    yPercentage = Math.min(Math.max(yPercentage, 0), 100);
-
-    const ctx = canvas.getContext('2d');
-    const x = xPercentage * canvas.width;
-    const y = yPercentage * canvas.height;
-
-    const imageData = ctx.getImageData(x, y, 1, 1);
-    const pixel = imageData.data;
-
-    if(debug) {
-        const clonedCanvas = document.createElement('canvas');
-                clonedCanvas.width = canvas.width;
-                clonedCanvas.height = canvas.height;
-
-        const clonedCtx = clonedCanvas.getContext('2d');
-                clonedCtx.drawImage(canvas, 0, 0);
-
-        clonedCtx.fillStyle = 'red';
-        clonedCtx.beginPath();
-        clonedCtx.arc(x, y, 1, 0, Math.PI * 2);
-        clonedCtx.fill();
-
-        const dataURL = clonedCanvas.toDataURL();
-
-        //console.log(canvas, pixel, dataURL);
-    }
-
-    return pixel[3] !== 0;
 }
 
 function getSiteData(dataType, obj) {
@@ -2046,12 +1946,6 @@ function getPieceElem(getAll) {
     const pieceElem = getSiteData('pieceElem', { boardQuerySelector, getAll });
 
     return pieceElem || null;
-}
-
-function getSquareElems(element) {
-    const squareElems = getSiteData('squareElems', { element });
-
-    return squareElems || null;
 }
 
 function getChessVariant() {
@@ -2328,8 +2222,6 @@ function observeNewMoves() {
 
     boardObserver = new MutationObserver(mutationArr => {
         try {
-            lastMutationObservationDate = Date.now();
-
             const mutationMoveArr = isMutationNewMove(mutationArr); // returns [isNewMove, turn]
             const isNewMove = mutationMoveArr?.[0];
             let turn = mutationMoveArr?.[1];

--- a/app/assets/js/globals.js
+++ b/app/assets/js/globals.js
@@ -456,19 +456,6 @@ function PARSE_MINMAX_FROM_STR(input) {
     return [min, max];
 }
 
-function COUNT_PIECES_FROM_FEN(fen) {
-    const pieceCount = {};
-    const position = fen.split(' ')[0];
-
-    for(let char of position) {
-        if(/[rnbqkpRNBQKP]/.test(char)) {
-            pieceCount[char] = (pieceCount[char] || 0) + 1;
-        }
-    }
-    
-    return pieceCount;
-}
-
 function COUNT_TOTAL_PIECES_FROM_FEN(fen) {
     let pieceCount = 0;
     const position = fen.split(' ')[0];
@@ -961,22 +948,6 @@ function FORMAT_CHESS_FONT(str) {
         ?.toLowerCase();
 }
 
-function GET_BOARD_DIMENSION_PERCENTAGES(boardDimensionsObj) {
-    const { width, height } = boardDimensionsObj;
-    const isSquare = width === height;
-
-    if(isSquare) {
-        return { 'width': 100, 'height': 100 };
-    }
-
-    const newWidth = width/height * 100;
-    const newHeight = height/width * 100;
-
-    return width > height 
-        ? { 'width': 100, 'height': newHeight }
-        : { 'width': newWidth, 'height': 100 };
-}
-
 function GET_BOARD_HEIGHT_FROM_WIDTH(widthPx, boardDimensionsObj) {
     return widthPx * (boardDimensionsObj.height / boardDimensionsObj.width);
 }
@@ -990,16 +961,6 @@ function GET_PIECE_STYLE_DIMENSIONS(boardDimensionsObj) {
 
 function GET_BACKGROUND_STYLE_DIMENSION(boardDimensionsObj) {
     return (100 / boardDimensionsObj.width) / (100 / 8) * 100;
-}
-
-function START_HEARTBEAT_LOOP(key) {
-    if(USERSCRIPT) {
-        return setInterval(() => {
-            USERSCRIPT.GM_setValue(key, true);
-        }, 1);
-    } else {
-        console.error("USERSCRIPT variable not found, can't start heart beat loop!");
-    }
 }
 
 function SET_INTERVAL_ASYNC(callback, interval) {
@@ -1019,15 +980,6 @@ function SET_INTERVAL_ASYNC(callback, interval) {
     loop();
 
     return { stop: () => running = false };
-}
-
-function GET_COOKIE(name) {
-    const cookies = document.cookie ? document.cookie.split('; ') : [];
-    for(let i = 0; i < cookies.length; i++) {
-        const cookie = cookies[i].split('=');
-        if(cookie[0] === name) return decodeURIComponent(cookie.slice(1).join('='));
-    }
-    return null;
 }
 
 async function WAIT_FOR_ELEMENT(selector, maxWaitTime = 10000000) {
@@ -1076,13 +1028,6 @@ function GET_NICE_PATH(path, limit = 60) {
 
 function IS_BELOW_VERSION(versionStr, targetVersion) {
     return versionStr.localeCompare(targetVersion, undefined, {numeric: true}) === -1;
-}
-
-function FORMAT_PROFILE_NAME(profileNameStr) {
-    return profileNameStr
-        .trim()
-        .replace(/[^a-zA-Z0-9]/g, '')
-        .replace(/\s+/g, '');
 }
 
 function IS_BASE64_PROFILE_NAME(value) {


### PR DESCRIPTION
Zero-reference helpers, grepped across the tree before deleting.

globals.js: COUNT_PIECES_FROM_FEN, GET_BOARD_DIMENSION_PERCENTAGES, GET_COOKIE, FORMAT_PROFILE_NAME and START_HEARTBEAT_LOOP - that last one calls USERSCRIPT.GM_setValue, which doesn’t exist on the bridge object, on a 1ms interval.

acas.user.js: getCanvasPixelColor, canvasHasPixelAt, getSquareElems, getElemCoordinatesFromLeftBottomPercentages, getFenPieceColor/getFenPieceOppositeColor, the unused onlyFlipX destructure, lastMutationObservationDate (written every mutation, never read), and startOffset = startOffset.